### PR TITLE
Replace semantic-release-docker plugin with bash commands + push additional tags

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -17,9 +17,19 @@ plugins:
           numReplacements: 1
 - - "@semantic-release/exec"
   - verifyConditionsCmd: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    verifyReleaseCmd: |
+      MAJOR_MINOR_PATCH=${/^((\d+)\.\d+)\.\d+$/.exec(nextRelease.version)}
+      if [ -z $MAJOR_MINOR_PATCH ]; then echo "Only SemVer versions with version core (major.minor.patch) supported!"; exit 1; fi
     prepareCmd: docker build -t $DOCKER_IMAGE:latest .
     publishCmd: |
-      docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE:${nextRelease.version}
+      MAJOR_MINOR_PATCH=${/^((\d+)\.\d+)\.\d+$/.exec(nextRelease.version)[0]}
+      MAJOR_MINOR=${      /^((\d+)\.\d+)\.\d+$/.exec(nextRelease.version)[1]}
+      MAJOR=${            /^((\d+)\.\d+)\.\d+$/.exec(nextRelease.version)[2]}
+      docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE:$MAJOR_MINOR_PATCH
+      docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE:$MAJOR_MINOR
+      docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE:$MAJOR
       docker push $DOCKER_IMAGE:latest
-      docker push $DOCKER_IMAGE:${nextRelease.version}
+      docker push $DOCKER_IMAGE:$MAJOR_MINOR_PATCH
+      docker push $DOCKER_IMAGE:$MAJOR_MINOR
+      docker push $DOCKER_IMAGE:$MAJOR
 - "@semantic-release/github"

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -16,7 +16,10 @@ plugins:
           numMatches: 1
           numReplacements: 1
 - - "@semantic-release/exec"
-  - prepareCmd: "docker build -t baloise/gitopscli ."
-- - "semantic-release-docker"
-  - name: "baloise/gitopscli"
+  - verifyConditionsCmd: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    prepareCmd: docker build -t $DOCKER_IMAGE:latest .
+    publishCmd: |
+      docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE:${nextRelease.version}
+      docker push $DOCKER_IMAGE:latest
+      docker push $DOCKER_IMAGE:${nextRelease.version}
 - "@semantic-release/github"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: shell
 
 env:
   global:
+    - DOCKER_IMAGE: baloise/gitopscli
     # DOCKER_USERNAME
     - secure: "Ecq9r+yXVc9gVdn1e4sDS/yegMKOyN3F6f4jxNSNl1pEkBZayVOvl6seh58sK+QzaIOLlrMYNlOzmWIKaekRuskYLJNYMUh67RJB24knOMSbA0hD3WPO8GbFY1Y/Xe1Gk5zKlLqFKe9OoCbM0ItGIXL2DrFPWl94F1YoZim2h7q6lFEo9NHvYSjreGMcqJujQKoN5/UkO76C3TEKNFXbyxev18nHwXQvqC2axbZONYEQuzYC7dDDAHRMxQ25t2qcWh19f/ssl0qR7VYheBY72Pypvl131+qIxaMl+r/7UeKHnhrM2/ineyo8VPfxhHwar31ldu0YyC0KtSYEMERASsKmJNyaP9d3mo6Vciws/8fGaU0FqlwfRPOhaa/ixMS43qJ4NS9vSogteQJVIIC4B9mHmFvzShDK5aDML+KJ0ehQnayS/30AywS80iSkSWdbkKPAdr+djVhUbey+LAWPVdmJOnIiBET4eSFqJ37dXmcKrhUcfrthL2SftkTGZ4Fm4gHPNYWXIej9N6kTwHlYzRkuJN3PNTLsqp9YE6dUYIUZEu0qkyX2IBljdOxLK5UTKzdkD+j8kLFEP2kN1ELbhP4qEBJj17swycTP9wR4RB+FfjsdeTXonaEOGq8z2CctnczJe87TJ1/GuRj5l/VXiK2ph25El/Axhg5Kv3lHxJw="
     # DOCKER_PASSWORD
@@ -37,7 +38,6 @@ jobs:
       services: docker
       install:
         - npm install semantic-release
-                      semantic-release-docker
                       @semantic-release/exec
                       @google/semantic-release-replace-plugin
                       conventional-changelog-conventionalcommits


### PR DESCRIPTION
1. replace [semantic-release-docker](https://github.com/felixfbecker/semantic-release-docker)  plugin
2. push additional `<major>` and `<major>.<minor>` tags to Docker Hub

The [semantic-release-docker](https://github.com/felixfbecker/semantic-release-docker) plugin is not very actively maintained and lacks a feature we need. If it supports `<major>` and `<major>.<minor>` tags in the future, we can switch back.

Fixes #88 