### PR TITLE
chore(refactor): move tmp dir creation/deletion to AbstractGitUtil

### DIFF
--- a/gitopscli/commands/add_pr_comment.py
+++ b/gitopscli/commands/add_pr_comment.py
@@ -7,15 +7,15 @@ def pr_comment_command(
     command, text, username, password, parent_id, pr_id, organisation, repository_name, git_provider, git_provider_url,
 ):
     assert command == "add-pr-comment"
-    apps_git = create_git(
-        username, password, None, None, organisation, repository_name, git_provider, git_provider_url, None,
-    )
-    if parent_id:
-        logging.info(
-            "Creating comment for PR %s as reply to comment %s with content: %s", pr_id, parent_id, text,
-        )
-    else:
-        logging.info(
-            "Creating comment for PR %s with content: %s", pr_id, text,
-        )
-    apps_git.add_pull_request_comment(pr_id, text, parent_id)
+    with create_git(
+        username, password, None, None, organisation, repository_name, git_provider, git_provider_url,
+    ) as apps_git:
+        if parent_id:
+            logging.info(
+                "Creating comment for PR %s as reply to comment %s with content: %s", pr_id, parent_id, text,
+            )
+        else:
+            logging.info(
+                "Creating comment for PR %s with content: %s", pr_id, text,
+            )
+        apps_git.add_pull_request_comment(pr_id, text, parent_id)

--- a/gitopscli/commands/create_pr_preview.py
+++ b/gitopscli/commands/create_pr_preview.py
@@ -2,7 +2,6 @@ import logging
 
 from gitopscli.commands.create_preview import create_preview_command
 from gitopscli.git.create_git import create_git
-from gitopscli.io.tmp_dir import create_tmp_dir, delete_tmp_dir
 
 
 def create_pr_preview_command(
@@ -20,20 +19,9 @@ def create_pr_preview_command(
 ):
     assert command == "create-pr-preview"
 
-    apps_tmp_dir = create_tmp_dir()
-
-    try:
-        apps_git = create_git(
-            username,
-            password,
-            git_user,
-            git_email,
-            organisation,
-            repository_name,
-            git_provider,
-            git_provider_url,
-            apps_tmp_dir,
-        )
+    with create_git(
+        username, password, git_user, git_email, organisation, repository_name, git_provider, git_provider_url,
+    ) as apps_git:
 
         pr_branch = apps_git.get_pull_request_branch(pr_id)
 
@@ -56,8 +44,6 @@ def create_pr_preview_command(
             __create_deployment_exist_callback(parent_id, pr_id, pr_branch),
             __create_deployment_new_callback(parent_id, pr_id, pr_branch),
         )
-    finally:
-        delete_tmp_dir(apps_tmp_dir)
 
 
 def __create_deployment_already_up_to_date_callback(parent_id, pr_id):

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -4,7 +4,6 @@ import uuid
 
 from gitopscli.git.create_git import create_git
 from gitopscli.io.yaml_util import update_yaml_file, yaml_dump
-from gitopscli.io.tmp_dir import create_tmp_dir, delete_tmp_dir
 from gitopscli.gitops_exception import GitOpsException
 
 
@@ -27,20 +26,9 @@ def deploy_command(
 ):
     assert command == "deploy"
 
-    tmp_dir = create_tmp_dir()
-
-    try:
-        git = create_git(
-            username,
-            password,
-            git_user,
-            git_email,
-            organisation,
-            repository_name,
-            git_provider,
-            git_provider_url,
-            tmp_dir,
-        )
+    with create_git(
+        username, password, git_user, git_email, organisation, repository_name, git_provider, git_provider_url,
+    ) as git:
         git.checkout("master")
         logging.info("Master checkout successful")
 
@@ -57,11 +45,9 @@ def deploy_command(
 
         git.push(config_branch)
         logging.info("Pushed branch %s", config_branch)
-    finally:
-        delete_tmp_dir(tmp_dir)
 
-    if create_pr:
-        __create_pr(git, config_branch, file, updated_values, auto_merge)
+        if create_pr:
+            __create_pr(git, config_branch, file, updated_values, auto_merge)
 
 
 def __update_values(git, file, values, single_commit, commit_message):

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -5,7 +5,6 @@ from ruamel.yaml import YAML
 
 from gitopscli.git.create_git import create_git
 from gitopscli.io.yaml_util import merge_yaml_element
-from gitopscli.io.tmp_dir import create_tmp_dir, delete_tmp_dir
 from gitopscli.gitops_exception import GitOpsException
 
 
@@ -24,37 +23,19 @@ def sync_apps_command(
 ):
     assert command == "sync-apps"
 
-    apps_tmp_dir = create_tmp_dir()
-    root_tmp_dir = create_tmp_dir()
-
-    try:
-        apps_git = create_git(
-            username,
-            password,
-            git_user,
-            git_email,
-            organisation,
-            repository_name,
-            git_provider,
-            git_provider_url,
-            apps_tmp_dir,
-        )
-        root_git = create_git(
-            username,
-            password,
-            git_user,
-            git_email,
-            root_organisation,
-            root_repository_name,
-            git_provider,
-            git_provider_url,
-            root_tmp_dir,
-        )
-
+    with create_git(
+        username, password, git_user, git_email, organisation, repository_name, git_provider, git_provider_url,
+    ) as apps_git, create_git(
+        username,
+        password,
+        git_user,
+        git_email,
+        root_organisation,
+        root_repository_name,
+        git_provider,
+        git_provider_url,
+    ) as root_git:
         __sync_apps(apps_git, root_git)
-    finally:
-        delete_tmp_dir(apps_tmp_dir)
-        delete_tmp_dir(root_tmp_dir)
 
 
 def __sync_apps(apps_git, root_git):

--- a/gitopscli/git/bitbucket_git_util.py
+++ b/gitopscli/git/bitbucket_git_util.py
@@ -7,10 +7,8 @@ from .abstract_git_util import AbstractGitUtil
 
 
 class BitBucketGitUtil(AbstractGitUtil):
-    def __init__(
-        self, tmp_dir, git_provider_url, organisation, repository_name, username, password, git_user, git_email
-    ):
-        super().__init__(tmp_dir, username, password, git_user, git_email)
+    def __init__(self, git_provider_url, organisation, repository_name, username, password, git_user, git_email):
+        super().__init__(username, password, git_user, git_email)
         self._git_provider_url = git_provider_url
         self._organisation = organisation
         self._repository_name = repository_name

--- a/gitopscli/git/create_git.py
+++ b/gitopscli/git/create_git.py
@@ -5,9 +5,7 @@ from gitopscli.git.github_git_util import GithubGitUtil
 from gitopscli.gitops_exception import GitOpsException
 
 
-def create_git(
-    username, password, git_user, git_email, organisation, repository_name, git_provider, git_provider_url, tmp_dir
-):
+def create_git(username, password, git_user, git_email, organisation, repository_name, git_provider, git_provider_url):
     if not git_provider:
         if "bitbucket" in git_provider_url:
             git_provider = "bitbucket-server"
@@ -21,7 +19,6 @@ def create_git(
         if not git_provider_url:
             raise GitOpsException("Please provide --git-provider-url for bitbucket-server")
         git = BitBucketGitUtil(
-            tmp_dir=tmp_dir,
             git_provider_url=git_provider_url,
             organisation=organisation,
             repository_name=repository_name,
@@ -32,7 +29,6 @@ def create_git(
         )
     elif git_provider == "github":
         git = GithubGitUtil(
-            tmp_dir=tmp_dir,
             organisation=organisation,
             repository_name=repository_name,
             username=username,

--- a/gitopscli/git/github_git_util.py
+++ b/gitopscli/git/github_git_util.py
@@ -5,8 +5,8 @@ from .abstract_git_util import AbstractGitUtil
 
 
 class GithubGitUtil(AbstractGitUtil):
-    def __init__(self, tmp_dir, organisation, repository_name, username, password, git_user, git_email):
-        super().__init__(tmp_dir, username, password, git_user, git_email)
+    def __init__(self, organisation, repository_name, username, password, git_user, git_email):
+        super().__init__(username, password, git_user, git_email)
         self._organisation = organisation
         self._repository_name = repository_name
         self._github = Github(self._username, self._password)

--- a/tests/commands/test_delete_preview.py
+++ b/tests/commands/test_delete_preview.py
@@ -1,5 +1,4 @@
 import unittest
-from uuid import UUID
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, Mock, call
 import pytest
@@ -17,8 +16,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
         # Monkey patch all external functions the command is using:
         self.os_path_exists_mock = add_patch("gitopscli.commands.delete_preview.os.path.exists")
         self.shutil_rmtree_mock = add_patch("gitopscli.commands.delete_preview.shutil.rmtree")
-        self.create_tmp_dir_mock = add_patch("gitopscli.commands.delete_preview.create_tmp_dir")
-        self.delete_tmp_dir_mock = add_patch("gitopscli.commands.delete_preview.delete_tmp_dir")
         self.logging_mock = add_patch("gitopscli.commands.delete_preview.logging")
         self.create_git_mock = add_patch("gitopscli.commands.delete_preview.create_git")
         self.git_util_mock = MagicMock()
@@ -29,26 +26,16 @@ class DeletePreviewCommandTest(unittest.TestCase):
 
         # Attach all mocks to a single mock manager
         self.mock_manager = Mock()
-        self.mock_manager.attach_mock(self.create_tmp_dir_mock, "create_tmp_dir")
         self.mock_manager.attach_mock(self.create_git_mock, "create_git")
         self.mock_manager.attach_mock(self.git_util_mock, "git_util")
-        self.mock_manager.attach_mock(self.delete_tmp_dir_mock, "delete_tmp_dir")
         self.mock_manager.attach_mock(self.os_path_exists_mock, "os.path.exists")
         self.mock_manager.attach_mock(self.shutil_rmtree_mock, "shutil.rmtree")
         self.mock_manager.attach_mock(self.logging_mock, "logging")
         self.mock_manager.attach_mock(self.gitops_config_mock, "GitOpsConfig")
         self.mock_manager.attach_mock(self.gitops_config_team_config_org_mock, "GitOpsConfig.team_config_org")
 
-        # Define some common default return values
-        self.create_tmp_dir_side_effect_count = 0
-
-        def create_tmp_dir_side_effect():
-            self.create_tmp_dir_side_effect_count += 1
-            return f"/tmp/created-tmp-dir-{self.create_tmp_dir_side_effect_count}"
-
-        self.create_tmp_dir_mock.side_effect = create_tmp_dir_side_effect
-
         self.create_git_mock.return_value = self.git_util_mock
+        self.git_util_mock.__enter__.return_value = self.git_util_mock
         self.git_util_mock.get_full_file_path.side_effect = lambda x: f"/tmp/created-tmp-dir/{x}"
         self.git_util_mock.create_pull_request.return_value = "<dummy-pr-object>"
         self.git_util_mock.get_pull_request_url.side_effect = lambda x: f"<url of {x}>"
@@ -72,35 +59,15 @@ class DeletePreviewCommandTest(unittest.TestCase):
             expect_preview_exists=False,
         )
 
-        assert self.mock_manager.mock_calls == [
-            call.create_tmp_dir(),
-            call.create_tmp_dir(),
-            call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "ORGA",
-                "REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-1",
-            ),
+        assert self.mock_manager.method_calls == [
+            call.create_git("USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "ORGA", "REPO", "github", None,),
             call.git_util.checkout("master"),
             call.logging.info("App repo '%s/%s' branch 'master' checkout successful", "ORGA", "REPO"),
             call.git_util.get_full_file_path(".gitops.config.yaml"),
             call.GitOpsConfig("/tmp/created-tmp-dir/.gitops.config.yaml"),
             call.logging.info("Read .gitops.config.yaml"),
             call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "TEAM_CONFIG_ORG",
-                "TEAM_CONFIG_REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-2",
+                "USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO", "github", None,
             ),
             call.git_util.checkout("master"),
             call.logging.info(
@@ -113,8 +80,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.git_util.commit("Delete preview environment for 'APP' and preview id 'PREVIEW_ID'."),
             call.git_util.push("master"),
             call.logging.info("Pushed branch 'master'"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-1"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-2"),
         ]
 
     def test_delete_missing_happy_flow(self):
@@ -134,35 +99,15 @@ class DeletePreviewCommandTest(unittest.TestCase):
             expect_preview_exists=False,
         )
 
-        assert self.mock_manager.mock_calls == [
-            call.create_tmp_dir(),
-            call.create_tmp_dir(),
-            call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "ORGA",
-                "REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-1",
-            ),
+        assert self.mock_manager.method_calls == [
+            call.create_git("USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "ORGA", "REPO", "github", None,),
             call.git_util.checkout("master"),
             call.logging.info("App repo '%s/%s' branch 'master' checkout successful", "ORGA", "REPO"),
             call.git_util.get_full_file_path(".gitops.config.yaml"),
             call.GitOpsConfig("/tmp/created-tmp-dir/.gitops.config.yaml"),
             call.logging.info("Read .gitops.config.yaml"),
             call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "TEAM_CONFIG_ORG",
-                "TEAM_CONFIG_REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-2",
+                "USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO", "github", None,
             ),
             call.git_util.checkout("master"),
             call.logging.info(
@@ -174,15 +119,10 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.logging.info(
                 "No preview environment for '%s' and preview id '%s'. Nothing to do..", "APP", "PREVIEW_ID"
             ),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-1"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-2"),
         ]
 
     def test_delete_missing_but_expected_error(self):
         self.os_path_exists_mock.return_value = False
-        self.git_util_mock.checkout.side_effect
-
-        FileNotFoundError
 
         with pytest.raises(GitOpsException) as ex:
             delete_preview_command(
@@ -200,35 +140,15 @@ class DeletePreviewCommandTest(unittest.TestCase):
             )
         self.assertEqual(str(ex.value), "There was no preview with name: APP-685912d3-preview")
 
-        assert self.mock_manager.mock_calls == [
-            call.create_tmp_dir(),
-            call.create_tmp_dir(),
-            call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "ORGA",
-                "REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-1",
-            ),
+        assert self.mock_manager.method_calls == [
+            call.create_git("USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "ORGA", "REPO", "github", None,),
             call.git_util.checkout("master"),
             call.logging.info("App repo '%s/%s' branch 'master' checkout successful", "ORGA", "REPO"),
             call.git_util.get_full_file_path(".gitops.config.yaml"),
             call.GitOpsConfig("/tmp/created-tmp-dir/.gitops.config.yaml"),
             call.logging.info("Read .gitops.config.yaml"),
             call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "TEAM_CONFIG_ORG",
-                "TEAM_CONFIG_REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-2",
+                "USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO", "github", None,
             ),
             call.git_util.checkout("master"),
             call.logging.info(
@@ -237,8 +157,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.logging.info("Preview folder name: %s", "APP-685912d3-preview"),
             call.git_util.get_full_file_path("APP-685912d3-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-685912d3-preview"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-1"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-2"),
         ]
 
     def test_missing_gitops_config_yaml_error(self):
@@ -260,24 +178,10 @@ class DeletePreviewCommandTest(unittest.TestCase):
             )
         self.assertEqual(str(ex.value), "Couldn't find .gitops.config.yaml")
 
-        assert self.mock_manager.mock_calls == [
-            call.create_tmp_dir(),
-            call.create_tmp_dir(),
-            call.create_git(
-                "USERNAME",
-                "PASSWORD",
-                "GIT_USER",
-                "GIT_EMAIL",
-                "ORGA",
-                "REPO",
-                "github",
-                None,
-                "/tmp/created-tmp-dir-1",
-            ),
+        assert self.mock_manager.method_calls == [
+            call.create_git("USERNAME", "PASSWORD", "GIT_USER", "GIT_EMAIL", "ORGA", "REPO", "github", None,),
             call.git_util.checkout("master"),
             call.logging.info("App repo '%s/%s' branch 'master' checkout successful", "ORGA", "REPO"),
             call.git_util.get_full_file_path(".gitops.config.yaml"),
             call.GitOpsConfig("/tmp/created-tmp-dir/.gitops.config.yaml"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-1"),
-            call.delete_tmp_dir("/tmp/created-tmp-dir-2"),
         ]

--- a/tests/git/test_abstract_git_util.py
+++ b/tests/git/test_abstract_git_util.py
@@ -40,7 +40,6 @@ class GitUtil(AbstractGitUtil):
 
 class AbstractGitUtilTest(unittest.TestCase):
     def setUp(self):
-        self.tmp_dir = self._create_tmp_dir()
         self.origin = self._create_origin()
 
     @staticmethod
@@ -76,143 +75,169 @@ class AbstractGitUtilTest(unittest.TestCase):
 
         return repo
 
-    def test_checkout_without_credentials(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
+    def test_finalize(self):
+        testee = GitUtil(username=None, password=None, git_user=None, git_email=None)
         testee.set_clone_url(self.origin.working_dir)
         testee.checkout("master")
 
-        readme = self._read_file(f"{self.tmp_dir}/repo/README.md")
-        self.assertEqual("master branch readme", readme)
+        tmp_dir = testee.get_full_file_path("..")
+        self.assertTrue(path.exists(tmp_dir))
 
-        self.assertFalse(path.exists(f"{self.tmp_dir}/credentials.sh"))
+        testee.finalize()
+        self.assertFalse(path.exists(tmp_dir))
+
+    def test_enter_and_exit_magic_methods(self):
+        testee = GitUtil(username=None, password=None, git_user=None, git_email=None)
+
+        self.assertEqual(testee, testee.__enter__())
+
+        testee.set_clone_url(self.origin.working_dir)
+        testee.checkout("master")
+
+        tmp_dir = testee.get_full_file_path("..")
+        self.assertTrue(path.exists(tmp_dir))
+
+        testee.__exit__(None, None, None)
+        self.assertFalse(path.exists(tmp_dir))
+
+    def test_checkout_without_credentials(self):
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
+
+            readme = self._read_file(testee.get_full_file_path("README.md"))
+            self.assertEqual("master branch readme", readme)
+
+            self.assertFalse(path.exists(testee.get_full_file_path("../credentials.sh")))
 
     def test_checkout_with_credentials(self):
-        testee = GitUtil(self.tmp_dir, username="USER", password="PASS", git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username="USER", password="PASS", git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        credentials_file = self._read_file(f"{self.tmp_dir}/credentials.sh")
-        self.assertEqual(
-            """\
+            credentials_file = self._read_file(testee.get_full_file_path("../credentials.sh"))
+            self.assertEqual(
+                """\
 #!/bin/sh
 echo username=USER
 echo password=PASS
 """,
-            credentials_file,
-        )
+                credentials_file,
+            )
 
     def test_checkout_branch(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("xyz")
-        readme = self._read_file(f"{self.tmp_dir}/repo/README.md")
-        self.assertEqual("xyz branch readme", readme)
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("xyz")
+            readme = self._read_file(testee.get_full_file_path("README.md"))
+            self.assertEqual("xyz branch readme", readme)
 
     def test_checkout_unknown_url(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url("invalid_url")
-        with pytest.raises(GitOpsException) as ex:
-            testee.checkout("master")
-        self.assertEqual("Error cloning 'invalid_url'", str(ex.value))
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url("invalid_url")
+            with pytest.raises(GitOpsException) as ex:
+                testee.checkout("master")
+            self.assertEqual("Error cloning 'invalid_url'", str(ex.value))
 
     def test_checkout_unknown_branch(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        with pytest.raises(GitOpsException) as ex:
-            testee.checkout("foo")
-        self.assertEqual("Error checking out branch 'foo'", str(ex.value))
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            with pytest.raises(GitOpsException) as ex:
+                testee.checkout("foo")
+            self.assertEqual("Error checking out branch 'foo'", str(ex.value))
 
     def test_get_full_file_path(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
-        self.assertEqual(Path(f"{self.tmp_dir}/repo/foo.bar"), testee.get_full_file_path("foo.bar"))
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
+            self.assertTrue(isinstance(testee.get_full_file_path("foo.bar"), Path))
+            self.assertRegex(str(testee.get_full_file_path("foo.bar")), r"^/tmp/gitopscli/[0-9a-f\-]+/repo/foo\.bar$")
 
     def test_new_branch(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        testee.new_branch("foo")
+            testee.new_branch("foo")
 
-        repo = Repo(f"{self.tmp_dir}/repo")
-        branches = [str(b) for b in repo.branches]
-        self.assertIn("foo", branches)
+            repo = Repo(testee.get_full_file_path("."))
+            branches = [str(b) for b in repo.branches]
+            self.assertIn("foo", branches)
 
     def test_new_branch_name_collision(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        with pytest.raises(GitOpsException) as ex:
-            testee.new_branch("xyz")
-        self.assertEqual("Error creating new branch 'xyz'.", str(ex.value))
+            with pytest.raises(GitOpsException) as ex:
+                testee.new_branch("xyz")
+            self.assertEqual("Error creating new branch 'xyz'.", str(ex.value))
 
     def test_commit(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user="john doe", git_email="john@doe.com")
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user="john doe", git_email="john@doe.com") as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        with open(f"{self.tmp_dir}/repo/foo.md", "w") as foo:
-            foo.write("new file")
-        with open(f"{self.tmp_dir}/repo/README.md", "w") as readme:
-            readme.write("new content")
-        testee.commit("new commit")
+            with open(testee.get_full_file_path("foo.md"), "w") as foo:
+                foo.write("new file")
+            with open(testee.get_full_file_path("README.md"), "w") as readme:
+                readme.write("new content")
+            testee.commit("new commit")
 
-        repo = Repo(f"{self.tmp_dir}/repo")
-        commits = list(repo.iter_commits("master"))
-        self.assertEqual(2, len(commits))
-        self.assertEqual("new commit\n", commits[0].message)
-        self.assertEqual("john doe", commits[0].author.name)
-        self.assertEqual("john@doe.com", commits[0].author.email)
-        self.assertIn("foo.md", commits[0].stats.files)
-        self.assertIn("README.md", commits[0].stats.files)
+            repo = Repo(testee.get_full_file_path("."))
+            commits = list(repo.iter_commits("master"))
+            self.assertEqual(2, len(commits))
+            self.assertEqual("new commit\n", commits[0].message)
+            self.assertEqual("john doe", commits[0].author.name)
+            self.assertEqual("john@doe.com", commits[0].author.email)
+            self.assertIn("foo.md", commits[0].stats.files)
+            self.assertIn("README.md", commits[0].stats.files)
 
     def test_commit_nothing_to_commit(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        testee.commit("empty commit")
+            testee.commit("empty commit")
 
-        repo = Repo(f"{self.tmp_dir}/repo")
-        commits = list(repo.iter_commits("master"))
-        self.assertEqual(1, len(commits))
-        self.assertEqual("initial commit\n", commits[0].message)
+            repo = Repo(testee.get_full_file_path("."))
+            commits = list(repo.iter_commits("master"))
+            self.assertEqual(1, len(commits))
+            self.assertEqual("initial commit\n", commits[0].message)
 
     def test_push(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        with open(f"{self.tmp_dir}/repo/foo.md", "w") as readme:
-            readme.write("new file")
-        util_repo = Repo(f"{self.tmp_dir}/repo")
-        util_repo.git.add("--all")
-        util_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
-        util_repo.git.commit("-m", "new commit")
+            with open(testee.get_full_file_path("foo.md"), "w") as readme:
+                readme.write("new file")
+            util_repo = Repo(testee.get_full_file_path("."))
+            util_repo.git.add("--all")
+            util_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            util_repo.git.commit("-m", "new commit")
 
-        testee.push("master")
+            testee.push("master")
 
-        commits = list(self.origin.iter_commits("master"))
-        self.assertEqual(2, len(commits))
-        self.assertEqual("new commit\n", commits[0].message)
+            commits = list(self.origin.iter_commits("master"))
+            self.assertEqual(2, len(commits))
+            self.assertEqual("new commit\n", commits[0].message)
 
     def test_push_no_changes(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        testee.push("master")
+            testee.push("master")
 
     def test_push_unknown_branch(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        with pytest.raises(GitOpsException) as ex:
-            testee.push("unknown")
-        assert str(ex.value).startswith("Error pushing branch 'unknown' to origin")
+            with pytest.raises(GitOpsException) as ex:
+                testee.push("unknown")
+            assert str(ex.value).startswith("Error pushing branch 'unknown' to origin")
 
     def test_push_commit_hook_error_reason_is_shown(self):
         repo_dir = self.origin.working_dir
@@ -220,31 +245,31 @@ echo password=PASS
             pre_receive_hook.write('echo >&2 "we reject this push"; exit 1')
         chmod(f"{repo_dir}/.git/hooks/pre-receive", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        with open(f"{self.tmp_dir}/repo/foo.md", "w") as readme:
-            readme.write("new file")
-        util_repo = Repo(f"{self.tmp_dir}/repo")
-        util_repo.git.add("--all")
-        util_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
-        util_repo.git.commit("-m", "new commit")
+            with open(testee.get_full_file_path("foo.md"), "w") as readme:
+                readme.write("new file")
+            util_repo = Repo(testee.get_full_file_path("."))
+            util_repo.git.add("--all")
+            util_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            util_repo.git.commit("-m", "new commit")
 
-        with pytest.raises(GitOpsException) as ex:
-            testee.push("master")
-        assert "pre-receive" in str(ex.value) and "we reject this push" in str(ex.value)
+            with pytest.raises(GitOpsException) as ex:
+                testee.push("master")
+            assert "pre-receive" in str(ex.value) and "we reject this push" in str(ex.value)
 
     def test_get_author_from_last_commit(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("master")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("master")
 
-        self.assertEqual("unit tester <unit@tester.com>", testee.get_author_from_last_commit())
+            self.assertEqual("unit tester <unit@tester.com>", testee.get_author_from_last_commit())
 
     def test_get_last_commit_hash(self):
-        testee = GitUtil(self.tmp_dir, username=None, password=None, git_user=None, git_email=None)
-        testee.set_clone_url(self.origin.working_dir)
-        testee.checkout("xyz")
+        with GitUtil(username=None, password=None, git_user=None, git_email=None) as testee:
+            testee.set_clone_url(self.origin.working_dir)
+            testee.checkout("xyz")
 
-        self.assertEqual(self.origin.head.commit.hexsha, testee.get_last_commit_hash())
+            self.assertEqual(self.origin.head.commit.hexsha, testee.get_last_commit_hash())

--- a/tests/git/test_create_git.py
+++ b/tests/git/test_create_git.py
@@ -17,7 +17,6 @@ class CreateGitTest(unittest.TestCase):
         mock_github_git_util_constructor.return_value = mock_github_git_util
 
         git = create_git(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -30,7 +29,6 @@ class CreateGitTest(unittest.TestCase):
 
         self.assertEqual(git, mock_github_git_util)
         mock_github_git_util_constructor.assert_called_with(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -45,7 +43,6 @@ class CreateGitTest(unittest.TestCase):
         mock_github_git_util_constructor.return_value = mock_github_git_util
 
         git = create_git(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -58,7 +55,6 @@ class CreateGitTest(unittest.TestCase):
 
         self.assertEqual(git, mock_github_git_util)
         mock_github_git_util_constructor.assert_called_with(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -73,7 +69,6 @@ class CreateGitTest(unittest.TestCase):
         mock_bitbucket_git_util_constructor.return_value = mock_bitbucket_git_util
 
         git = create_git(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -86,7 +81,6 @@ class CreateGitTest(unittest.TestCase):
 
         self.assertEqual(git, mock_bitbucket_git_util)
         mock_bitbucket_git_util_constructor.assert_called_with(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -99,7 +93,6 @@ class CreateGitTest(unittest.TestCase):
     def test_bitbucket_server_missing_git_provider_url(self):
         with pytest.raises(GitOpsException) as ex:
             create_git(
-                tmp_dir="TMP_DIR",
                 username="USER",
                 password="PASS",
                 git_user="GIT_USER",
@@ -117,7 +110,6 @@ class CreateGitTest(unittest.TestCase):
         mock_bitbucket_git_util_constructor.return_value = mock_bitbucket_git_util
 
         git = create_git(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -130,7 +122,6 @@ class CreateGitTest(unittest.TestCase):
 
         self.assertEqual(git, mock_bitbucket_git_util)
         mock_bitbucket_git_util_constructor.assert_called_with(
-            tmp_dir="TMP_DIR",
             username="USER",
             password="PASS",
             git_user="GIT_USER",
@@ -143,7 +134,6 @@ class CreateGitTest(unittest.TestCase):
     def test_unknown_git_provider(self):
         with pytest.raises(GitOpsException) as ex:
             create_git(
-                tmp_dir="TMP_DIR",
                 username="USER",
                 password="PASS",
                 git_user="GIT_USER",
@@ -158,7 +148,6 @@ class CreateGitTest(unittest.TestCase):
     def test_cannot_infer_git_provider_from_url(self):
         with pytest.raises(GitOpsException) as ex:
             create_git(
-                tmp_dir="TMP_DIR",
                 username="USER",
                 password="PASS",
                 git_user="GIT_USER",


### PR DESCRIPTION
Users of GitUtil should not need to think about creation and deletion of a temporary workdir to checkout the repo.