### PR TITLE
Move git related logging into single place

### DIFF
--- a/gitopscli/commands/add_pr_comment.py
+++ b/gitopscli/commands/add_pr_comment.py
@@ -1,5 +1,3 @@
-import logging
-
 from gitopscli.git import GitApiConfig, GitRepoApiFactory
 
 
@@ -9,12 +7,4 @@ def pr_comment_command(
     assert command == "add-pr-comment"
     git_api_config = GitApiConfig(username, password, git_provider, git_provider_url,)
     git_repo_api = GitRepoApiFactory.create(git_api_config, organisation, repository_name,)
-    if parent_id:
-        logging.info(
-            "Creating comment for PR %s as reply to comment %s with content: %s", pr_id, parent_id, text,
-        )
-    else:
-        logging.info(
-            "Creating comment for PR %s with content: %s", pr_id, text,
-        )
     git_repo_api.add_pull_request_comment(pr_id, text, parent_id)

--- a/gitopscli/commands/create_pr_preview.py
+++ b/gitopscli/commands/create_pr_preview.py
@@ -20,7 +20,7 @@ def create_pr_preview_command(
     git_repo_api = GitRepoApiFactory.create(git_api_config, organisation, repository_name)
 
     pr_branch = git_repo_api.get_pull_request_branch(pr_id)
-    git_hash = git_repo_api.get_branch_head_hash("master")
+    git_hash = git_repo_api.get_branch_head_hash(pr_branch)
 
     add_pr_comment = lambda comment: git_repo_api.add_pull_request_comment(pr_id, comment, parent_id)
 

--- a/gitopscli/commands/create_pr_preview.py
+++ b/gitopscli/commands/create_pr_preview.py
@@ -1,5 +1,3 @@
-import logging
-
 from gitopscli.commands.create_preview import create_preview_command
 from gitopscli.git import GitApiConfig, GitRepoApiFactory
 
@@ -24,9 +22,7 @@ def create_pr_preview_command(
     pr_branch = git_repo_api.get_pull_request_branch(pr_id)
     git_hash = git_repo_api.get_branch_head_hash("master")
 
-    def add_pr_comment(comment):
-        logging.info("Adding comment to pull request with id %s: %s", pr_id, comment)
-        git_repo_api.add_pull_request_comment(pr_id, comment, parent_id)
+    add_pr_comment = lambda comment: git_repo_api.add_pull_request_comment(pr_id, comment, parent_id)
 
     create_preview_command(
         command="create-preview",

--- a/gitopscli/commands/create_pr_preview.py
+++ b/gitopscli/commands/create_pr_preview.py
@@ -22,7 +22,7 @@ def create_pr_preview_command(
     git_repo_api = GitRepoApiFactory.create(git_api_config, organisation, repository_name)
 
     pr_branch = git_repo_api.get_pull_request_branch(pr_id)
-    git_hash = git_repo_api.get_branch_head_hash()
+    git_hash = git_repo_api.get_branch_head_hash("master")
 
     def add_pr_comment(comment):
         logging.info("Adding comment to pull request with id %s: %s", pr_id, comment)

--- a/gitopscli/commands/create_preview.py
+++ b/gitopscli/commands/create_preview.py
@@ -36,7 +36,6 @@ def create_preview_command(
     )
     with GitRepo(config_git_repo_api) as config_git_repo:
         config_git_repo.checkout("master")
-        logging.info("Config repo branch master checkout successful")
 
         preview_template_folder_name = ".preview-templates/" + gitops_config.application_name
         if not os.path.isdir(config_git_repo.get_full_file_path(preview_template_folder_name)):
@@ -79,7 +78,6 @@ def create_preview_command(
             f"{commit_msg_verb} preview environment for '{gitops_config.application_name}' and git hash '{git_hash}'.",
         )
         config_git_repo.push("master")
-        logging.info("Pushed branch master")
 
         if preview_env_already_exist:
             deployment_exists_callback(route_host)

--- a/gitopscli/commands/delete_preview.py
+++ b/gitopscli/commands/delete_preview.py
@@ -33,11 +33,6 @@ def delete_preview_command(
     )
     with GitRepo(config_git_repo_api) as config_git_repo:
         config_git_repo.checkout("master")
-        logging.info(
-            "Config repo '%s/%s' branch 'master' checkout successful",
-            gitops_config.team_config_org,
-            gitops_config.team_config_repo,
-        )
         hashed_preview_id = hashlib.sha256(preview_id.encode("utf-8")).hexdigest()[:8]
         preview_folder_name = gitops_config.application_name + "-" + hashed_preview_id + "-preview"
         logging.info("Preview folder name: %s", preview_folder_name)
@@ -55,7 +50,6 @@ def delete_preview_command(
                 f"Delete preview environment for '{gitops_config.application_name}' and preview id '{preview_id}'.",
             )
             config_git_repo.push("master")
-            logging.info("Pushed branch 'master'")
         else:
             logging.info(
                 "No preview environment for '%s' and preview id '%s'. Nothing to do..",

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -96,11 +96,6 @@ Updated {len(updated_values)} value{'s' if len(updated_values) > 1 else ''} in `
 ```
 """
     pull_request = git_repo_api.create_pull_request(branch, "master", title, description)
-    logging.info("Pull request created: %s", pull_request.url)
-
     if auto_merge:
         git_repo_api.merge_pull_request(pull_request.pr_id)
-        logging.info("Pull request merged")
-
         git_repo_api.delete_branch(branch)
-        logging.info("Branch '%s' deleted", branch)

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -29,13 +29,11 @@ def deploy_command(
     git_repo_api = GitRepoApiFactory.create(git_api_config, organisation, repository_name)
     with GitRepo(git_repo_api) as git_repo:
         git_repo.checkout("master")
-        logging.info("Master checkout successful")
 
         config_branch = f"gitopscli-deploy-{str(uuid.uuid4())[:8]}" if create_pr else "master"
 
         if create_pr:
             git_repo.new_branch(config_branch)
-            logging.info("Created branch %s", config_branch)
 
         updated_values = __update_values(git_repo, git_user, git_email, file, values, single_commit, commit_message)
         if not updated_values:
@@ -43,7 +41,6 @@ def deploy_command(
             return
 
         git_repo.push(config_branch)
-        logging.info("Pushed branch %s", config_branch)
 
     if create_pr:
         __create_pr(git_repo_api, config_branch, file, updated_values, auto_merge)

--- a/gitopscli/git/bitbucket_git_repo_api_adapter.py
+++ b/gitopscli/git/bitbucket_git_repo_api_adapter.py
@@ -76,7 +76,7 @@ class BitbucketGitRepoApiAdapter(GitRepoApi):
             self.__organisation, self.__repository_name, pull_request["id"], pull_request["version"]
         )
 
-    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: str = None) -> None:
+    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: Optional[str] = None) -> None:
         pull_request_comment = self.__bitbucket.add_pull_request_comment(
             self.__organisation, self.__repository_name, pr_id, text, parent_id
         )

--- a/gitopscli/git/git_repo_api.py
+++ b/gitopscli/git/git_repo_api.py
@@ -30,7 +30,7 @@ class GitRepoApi(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: str = None) -> None:
+    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/gitopscli/git/git_repo_api_factory.py
+++ b/gitopscli/git/git_repo_api_factory.py
@@ -2,6 +2,7 @@ from gitopscli.gitops_exception import GitOpsException
 from .git_repo_api import GitRepoApi
 from .github_git_repo_api_adapter import GithubGitRepoApiAdapter
 from .bitbucket_git_repo_api_adapter import BitbucketGitRepoApiAdapter
+from .git_repo_api_logging_proxy import GitRepoApiLoggingProxy
 
 from .git_api_config import GitApiConfig
 
@@ -29,4 +30,4 @@ class GitRepoApiFactory:  # pylint: disable=too-few-public-methods
             )
         else:
             raise GitOpsException(f"Unknown git provider: {config.git_provider}")
-        return git_repo_api
+        return GitRepoApiLoggingProxy(git_repo_api)

--- a/gitopscli/git/git_repo_api_logging_proxy.py
+++ b/gitopscli/git/git_repo_api_logging_proxy.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 from .git_repo_api import GitRepoApi
 
@@ -18,15 +19,26 @@ class GitRepoApiLoggingProxy(GitRepoApi):
     def create_pull_request(
         self, from_branch: str, to_branch: str, title: str, description: str
     ) -> GitRepoApi.PullRequestIdAndUrl:
+        logging.info("Creating pull request from '%s' to '%s' with title: %s", from_branch, to_branch, title)
         return self.__api.create_pull_request(from_branch, to_branch, title, description)
 
     def merge_pull_request(self, pr_id: str) -> None:
+        logging.info("Merging pull request %s", pr_id)
         self.__api.merge_pull_request(pr_id)
 
     def add_pull_request_comment(self, pr_id: str, text: str, parent_id: Optional[str] = None) -> None:
+        if parent_id:
+            logging.info(
+                "Creating comment for pull request %s as reply to comment %s with content: %s", pr_id, parent_id, text,
+            )
+        else:
+            logging.info(
+                "Creating comment for pull request %s with content: %s", pr_id, text,
+            )
         self.__api.add_pull_request_comment(pr_id, text, parent_id)
 
     def delete_branch(self, branch: str) -> None:
+        logging.info("Deleting branch '%s'", branch)
         self.__api.delete_branch(branch)
 
     def get_branch_head_hash(self, branch: str) -> str:

--- a/gitopscli/git/git_repo_api_logging_proxy.py
+++ b/gitopscli/git/git_repo_api_logging_proxy.py
@@ -1,0 +1,36 @@
+from typing import Optional
+from .git_repo_api import GitRepoApi
+
+
+class GitRepoApiLoggingProxy(GitRepoApi):
+    def __init__(self, git_repo_api: GitRepoApi) -> None:
+        self.__api = git_repo_api
+
+    def get_username(self) -> Optional[str]:
+        return self.__api.get_username()
+
+    def get_password(self) -> Optional[str]:
+        return self.__api.get_password()
+
+    def get_clone_url(self) -> str:
+        return self.__api.get_clone_url()
+
+    def create_pull_request(
+        self, from_branch: str, to_branch: str, title: str, description: str
+    ) -> GitRepoApi.PullRequestIdAndUrl:
+        return self.__api.create_pull_request(from_branch, to_branch, title, description)
+
+    def merge_pull_request(self, pr_id: str) -> None:
+        self.__api.merge_pull_request(pr_id)
+
+    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: Optional[str] = None) -> None:
+        self.__api.add_pull_request_comment(pr_id, text, parent_id)
+
+    def delete_branch(self, branch: str) -> None:
+        self.__api.delete_branch(branch)
+
+    def get_branch_head_hash(self, branch: str) -> str:
+        return self.__api.get_branch_head_hash(branch)
+
+    def get_pull_request_branch(self, pr_id: str) -> str:
+        return self.__api.get_pull_request_branch(pr_id)

--- a/gitopscli/git/github_git_repo_api_adapter.py
+++ b/gitopscli/git/github_git_repo_api_adapter.py
@@ -34,7 +34,7 @@ class GithubGitRepoApiAdapter(GitRepoApi):
         pull_request = self.__get_pull_request(pr_id)
         pull_request.merge()
 
-    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: str = None) -> None:
+    def add_pull_request_comment(self, pr_id: str, text: str, parent_id: Optional[str] = None) -> None:
         pull_request = self.__get_pull_request(pr_id)
         pull_request.create_issue_comment(text)
 

--- a/tests/commands/test_add_pr_comment.py
+++ b/tests/commands/test_add_pr_comment.py
@@ -16,7 +16,6 @@ class AddPrCommentCommandTest(unittest.TestCase):
             return patcher.start()
 
         # Monkey patch all external functions the command is using:
-        self.logging_mock = add_patch("gitopscli.commands.add_pr_comment.logging")
         self.git_repo_api_factory_mock = add_patch("gitopscli.commands.add_pr_comment.GitRepoApiFactory")
         self.git_repo_api_mock = MagicMock()
 
@@ -24,7 +23,6 @@ class AddPrCommentCommandTest(unittest.TestCase):
         self.mock_manager = Mock()
         self.mock_manager.attach_mock(self.git_repo_api_factory_mock, "GitRepoApiFactory")
         self.mock_manager.attach_mock(self.git_repo_api_mock, "GitRepoApi")
-        self.mock_manager.attach_mock(self.logging_mock, "logging")
 
         # Define some common default return values
         self.git_repo_api_factory_mock.create.return_value = self.git_repo_api_mock
@@ -45,12 +43,6 @@ class AddPrCommentCommandTest(unittest.TestCase):
 
         assert self.mock_manager.mock_calls == [
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
-            call.logging.info(
-                "Creating comment for PR %s as reply to comment %s with content: %s",
-                "<PR ID>",
-                "<PARENT ID>",
-                "Hello World!",
-            ),
             call.GitRepoApi.add_pull_request_comment("<PR ID>", "Hello World!", "<PARENT ID>"),
         ]
 
@@ -70,6 +62,5 @@ class AddPrCommentCommandTest(unittest.TestCase):
 
         assert self.mock_manager.mock_calls == [
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
-            call.logging.info("Creating comment for PR %s with content: %s", "<PR ID>", "Hello World!",),
             call.GitRepoApi.add_pull_request_comment("<PR ID>", "Hello World!", None),
         ]

--- a/tests/commands/test_delete_pr_preview.py
+++ b/tests/commands/test_delete_pr_preview.py
@@ -68,9 +68,6 @@ class DeletePRPreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-7252ebf0-preview"),
             call.GitRepo.get_full_file_path("APP-7252ebf0-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-7252ebf0-preview"),
@@ -79,7 +76,6 @@ class DeletePRPreviewCommandTest(unittest.TestCase):
                 "GIT_USER", "GIT_EMAIL", "Delete preview environment for 'APP' and preview id 'some/branch'."
             ),
             call.GitRepo.push("master"),
-            call.logging.info("Pushed branch 'master'"),
         ]
 
     def test_delete_missing_happy_flow(self):
@@ -106,9 +102,6 @@ class DeletePRPreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-7252ebf0-preview"),
             call.GitRepo.get_full_file_path("APP-7252ebf0-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-7252ebf0-preview"),
@@ -144,9 +137,6 @@ class DeletePRPreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-7252ebf0-preview"),
             call.GitRepo.get_full_file_path("APP-7252ebf0-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-7252ebf0-preview"),

--- a/tests/commands/test_delete_preview.py
+++ b/tests/commands/test_delete_preview.py
@@ -68,9 +68,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-685912d3-preview"),
             call.GitRepo.get_full_file_path("APP-685912d3-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-685912d3-preview"),
@@ -79,7 +76,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
                 "GIT_USER", "GIT_EMAIL", "Delete preview environment for 'APP' and preview id 'PREVIEW_ID'."
             ),
             call.GitRepo.push("master"),
-            call.logging.info("Pushed branch 'master'"),
         ]
 
     def test_delete_missing_happy_flow(self):
@@ -106,9 +102,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-685912d3-preview"),
             call.GitRepo.get_full_file_path("APP-685912d3-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-685912d3-preview"),
@@ -144,9 +137,6 @@ class DeletePreviewCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(expected_git_api_config, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info(
-                "Config repo '%s/%s' branch 'master' checkout successful", "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO"
-            ),
             call.logging.info("Preview folder name: %s", "APP-685912d3-preview"),
             call.GitRepo.get_full_file_path("APP-685912d3-preview"),
             call.os.path.exists("/tmp/created-tmp-dir/APP-685912d3-preview"),

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -71,7 +71,6 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
@@ -81,7 +80,6 @@ class DeployCommandTest(unittest.TestCase):
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", "changed 'a.b.d' to 'bar' in test/file.yml"),
             call.GitRepo.push("master"),
-            call.logging.info("Pushed branch %s", "master"),
         ]
 
     def test_create_pr_happy_flow(self):
@@ -106,9 +104,7 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.new_branch("gitopscli-deploy-b973b5bb"),
-            call.logging.info("Created branch %s", "gitopscli-deploy-b973b5bb"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
@@ -118,7 +114,6 @@ class DeployCommandTest(unittest.TestCase):
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", "changed 'a.b.d' to 'bar' in test/file.yml"),
             call.GitRepo.push("gitopscli-deploy-b973b5bb"),
-            call.logging.info("Pushed branch %s", "gitopscli-deploy-b973b5bb"),
             call.GitRepoApi.create_pull_request(
                 "gitopscli-deploy-b973b5bb",
                 "master",
@@ -149,9 +144,7 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.new_branch("gitopscli-deploy-b973b5bb"),
-            call.logging.info("Created branch %s", "gitopscli-deploy-b973b5bb"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
@@ -161,7 +154,6 @@ class DeployCommandTest(unittest.TestCase):
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", "changed 'a.b.d' to 'bar' in test/file.yml"),
             call.GitRepo.push("gitopscli-deploy-b973b5bb"),
-            call.logging.info("Pushed branch %s", "gitopscli-deploy-b973b5bb"),
             call.GitRepoApi.create_pull_request(
                 "gitopscli-deploy-b973b5bb",
                 "master",
@@ -194,7 +186,6 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
@@ -203,7 +194,6 @@ class DeployCommandTest(unittest.TestCase):
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", "updated 2 values in test/file.yml\n\na.b.c: foo\na.b.d: bar"),
             call.GitRepo.push("master"),
-            call.logging.info("Pushed branch %s", "master"),
         ]
 
     def test_commit_message_happy_flow(self):
@@ -229,7 +219,6 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
@@ -238,7 +227,6 @@ class DeployCommandTest(unittest.TestCase):
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", "testcommit"),
             call.GitRepo.push("master"),
-            call.logging.info("Pushed branch %s", "master"),
         ]
 
     def test_checkout_error(self):
@@ -296,7 +284,6 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
         ]
@@ -325,7 +312,6 @@ class DeployCommandTest(unittest.TestCase):
             call.GitRepoApiFactory.create(self._expected_github_api_config, "ORGA", "REPO"),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.checkout("master"),
-            call.logging.info("Master checkout successful"),
             call.GitRepo.get_full_file_path("test/file.yml"),
             call.os.path.isfile("/tmp/created-tmp-dir/test/file.yml"),
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -125,7 +125,6 @@ class DeployCommandTest(unittest.TestCase):
                 "Updated values in test/file.yml",
                 "Updated 2 values in `test/file.yml`:\n```yaml\na.b.c: foo\na.b.d: bar\n```\n",
             ),
-            call.logging.info("Pull request created: %s", "<url of dummy pr>"),
         ]
 
     def test_create_pr_and_merge_happy_flow(self):
@@ -169,11 +168,8 @@ class DeployCommandTest(unittest.TestCase):
                 "Updated values in test/file.yml",
                 "Updated 2 values in `test/file.yml`:\n```yaml\na.b.c: foo\na.b.d: bar\n```\n",
             ),
-            call.logging.info("Pull request created: %s", "<url of dummy pr>"),
             call.GitRepoApi.merge_pull_request("<dummy pr id>"),
-            call.logging.info("Pull request merged"),
             call.GitRepoApi.delete_branch("gitopscli-deploy-b973b5bb"),
-            call.logging.info("Branch '%s' deleted", "gitopscli-deploy-b973b5bb"),
         ]
 
     def test_single_commit_happy_flow(self):

--- a/tests/git/test_git_repo_api_logging_proxy.py
+++ b/tests/git/test_git_repo_api_logging_proxy.py
@@ -1,15 +1,8 @@
-from os import path, makedirs, chmod
-import stat
 import unittest
-import uuid
-from unittest.mock import MagicMock
-from pathlib import Path
-from git import Repo
-import pytest
+from unittest.mock import MagicMock, patch
 
-from gitopscli.git import GitRepo, GitRepoApi
+from gitopscli.git import GitRepoApi
 from gitopscli.git.git_repo_api_logging_proxy import GitRepoApiLoggingProxy
-from gitopscli.gitops_exception import GitOpsException
 
 
 class GitRepoApiLoggingProxyTest(unittest.TestCase):
@@ -44,7 +37,8 @@ class GitRepoApiLoggingProxyTest(unittest.TestCase):
         self.assertEqual(actual_return_value, expected_return_value)
         self.__mock_repo_api.get_clone_url.assert_called_once_with()
 
-    def test_create_pull_request(self):
+    @patch("gitopscli.git.git_repo_api_logging_proxy.logging")
+    def test_create_pull_request(self, logging_mock):
         expected_return_value = GitRepoApi.PullRequestIdAndUrl("<id>", "<url>")
         self.__mock_repo_api.create_pull_request.return_value = expected_return_value
 
@@ -56,18 +50,44 @@ class GitRepoApiLoggingProxyTest(unittest.TestCase):
         self.__mock_repo_api.create_pull_request.assert_called_once_with(
             "<from branch>", "<to branch>", "<title>", "<description>"
         )
+        logging_mock.info.assert_called_once_with(
+            "Creating pull request from '%s' to '%s' with title: %s", "<from branch>", "<to branch>", "<title>",
+        )
 
-    def test_merge_pull_request(self):
+    @patch("gitopscli.git.git_repo_api_logging_proxy.logging")
+    def test_merge_pull_request(self, logging_mock):
         self.__testee.merge_pull_request(pr_id="<pr_id>")
         self.__mock_repo_api.merge_pull_request.assert_called_once_with("<pr_id>")
+        logging_mock.info.assert_called_once_with(
+            "Merging pull request %s", "<pr_id>",
+        )
 
-    def test_add_pull_request_comment(self):
+    @patch("gitopscli.git.git_repo_api_logging_proxy.logging")
+    def test_add_pull_request_comment(self, logging_mock):
         self.__testee.add_pull_request_comment(pr_id="<pr_id>", text="<text>", parent_id="<parent_id>")
         self.__mock_repo_api.add_pull_request_comment.assert_called_once_with("<pr_id>", "<text>", "<parent_id>")
+        logging_mock.info.assert_called_once_with(
+            "Creating comment for pull request %s as reply to comment %s with content: %s",
+            "<pr_id>",
+            "<parent_id>",
+            "<text>",
+        )
 
-    def test_delete_branch(self):
+    @patch("gitopscli.git.git_repo_api_logging_proxy.logging")
+    def test_add_pull_request_comment_without_parent_id(self, logging_mock):
+        self.__testee.add_pull_request_comment(pr_id="<pr_id>", text="<text>", parent_id=None)
+        self.__mock_repo_api.add_pull_request_comment.assert_called_once_with("<pr_id>", "<text>", None)
+        logging_mock.info.assert_called_once_with(
+            "Creating comment for pull request %s with content: %s", "<pr_id>", "<text>",
+        )
+
+    @patch("gitopscli.git.git_repo_api_logging_proxy.logging")
+    def test_delete_branch(self, logging_mock):
         self.__testee.delete_branch("<branch>")
         self.__mock_repo_api.delete_branch.assert_called_once_with("<branch>")
+        logging_mock.info.assert_called_once_with(
+            "Deleting branch '%s'", "<branch>",
+        )
 
     def test_get_branch_head_hash(self):
         expected_return_value = "<hash>"

--- a/tests/git/test_git_repo_api_logging_proxy.py
+++ b/tests/git/test_git_repo_api_logging_proxy.py
@@ -1,0 +1,88 @@
+from os import path, makedirs, chmod
+import stat
+import unittest
+import uuid
+from unittest.mock import MagicMock
+from pathlib import Path
+from git import Repo
+import pytest
+
+from gitopscli.git import GitRepo, GitRepoApi
+from gitopscli.git.git_repo_api_logging_proxy import GitRepoApiLoggingProxy
+from gitopscli.gitops_exception import GitOpsException
+
+
+class GitRepoApiLoggingProxyTest(unittest.TestCase):
+    def setUp(self):
+        self.__mock_repo_api: GitRepoApi = MagicMock()
+        self.__testee = GitRepoApiLoggingProxy(self.__mock_repo_api)
+
+    def test_get_username(self):
+        expected_return_value = "<username>"
+        self.__mock_repo_api.get_username.return_value = expected_return_value
+
+        actual_return_value = self.__testee.get_username()
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.get_username.assert_called_once_with()
+
+    def test_get_password(self):
+        expected_return_value = "<password>"
+        self.__mock_repo_api.get_password.return_value = expected_return_value
+
+        actual_return_value = self.__testee.get_password()
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.get_password.assert_called_once_with()
+
+    def test_get_clone_url(self):
+        expected_return_value = "<clone url>"
+        self.__mock_repo_api.get_clone_url.return_value = expected_return_value
+
+        actual_return_value = self.__testee.get_clone_url()
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.get_clone_url.assert_called_once_with()
+
+    def test_create_pull_request(self):
+        expected_return_value = GitRepoApi.PullRequestIdAndUrl("<id>", "<url>")
+        self.__mock_repo_api.create_pull_request.return_value = expected_return_value
+
+        actual_return_value = self.__testee.create_pull_request(
+            from_branch="<from branch>", to_branch="<to branch>", title="<title>", description="<description>"
+        )
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.create_pull_request.assert_called_once_with(
+            "<from branch>", "<to branch>", "<title>", "<description>"
+        )
+
+    def test_merge_pull_request(self):
+        self.__testee.merge_pull_request(pr_id="<pr_id>")
+        self.__mock_repo_api.merge_pull_request.assert_called_once_with("<pr_id>")
+
+    def test_add_pull_request_comment(self):
+        self.__testee.add_pull_request_comment(pr_id="<pr_id>", text="<text>", parent_id="<parent_id>")
+        self.__mock_repo_api.add_pull_request_comment.assert_called_once_with("<pr_id>", "<text>", "<parent_id>")
+
+    def test_delete_branch(self):
+        self.__testee.delete_branch("<branch>")
+        self.__mock_repo_api.delete_branch.assert_called_once_with("<branch>")
+
+    def test_get_branch_head_hash(self):
+        expected_return_value = "<hash>"
+        self.__mock_repo_api.get_branch_head_hash.return_value = expected_return_value
+
+        actual_return_value = self.__testee.get_branch_head_hash("<branch>")
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.get_branch_head_hash.assert_called_once_with("<branch>")
+
+    def test_get_pull_request_branch(self):
+        expected_return_value = "<hash>"
+        self.__mock_repo_api.get_pull_request_branch.return_value = expected_return_value
+
+        actual_return_value = self.__testee.get_pull_request_branch("<pr_id>")
+
+        self.assertEqual(actual_return_value, expected_return_value)
+        self.__mock_repo_api.get_pull_request_branch.assert_called_once_with("<pr_id>")

--- a/tests/git/test_repo_api_factory.py
+++ b/tests/git/test_repo_api_factory.py
@@ -6,10 +6,14 @@ from gitopscli.git import GitRepoApiFactory, GitApiConfig
 
 
 class GitRepoApiFactoryTest(unittest.TestCase):
+    @patch("gitopscli.git.git_repo_api_factory.GitRepoApiLoggingProxy")
     @patch("gitopscli.git.git_repo_api_factory.GithubGitRepoApiAdapter")
-    def test_create_github(self, mock_github_adapter_constructor):
+    def test_create_github(self, mock_github_adapter_constructor, mock_logging_proxy_constructor):
         mock_github_adapter = MagicMock()
         mock_github_adapter_constructor.return_value = mock_github_adapter
+
+        mock_logging_proxy = MagicMock()
+        mock_logging_proxy_constructor.return_value = mock_logging_proxy
 
         git_repo_api = GitRepoApiFactory.create(
             config=GitApiConfig(username="USER", password="PASS", git_provider="github", git_provider_url=None,),
@@ -17,16 +21,21 @@ class GitRepoApiFactoryTest(unittest.TestCase):
             repository_name="REPO",
         )
 
-        self.assertEqual(git_repo_api, mock_github_adapter)
+        self.assertEqual(git_repo_api, mock_logging_proxy)
 
         mock_github_adapter_constructor.assert_called_with(
             username="USER", password="PASS", organisation="ORG", repository_name="REPO",
         )
+        mock_logging_proxy_constructor.assert_called_with(mock_github_adapter)
 
+    @patch("gitopscli.git.git_repo_api_factory.GitRepoApiLoggingProxy")
     @patch("gitopscli.git.git_repo_api_factory.BitbucketGitRepoApiAdapter")
-    def test_create_bitbucket(self, mock_bitbucket_adapter_constructor):
+    def test_create_bitbucket(self, mock_bitbucket_adapter_constructor, mock_logging_proxy_constructor):
         mock_bitbucket_adapter = MagicMock()
         mock_bitbucket_adapter_constructor.return_value = mock_bitbucket_adapter
+
+        mock_logging_proxy = MagicMock()
+        mock_logging_proxy_constructor.return_value = mock_logging_proxy
 
         git_repo_api = GitRepoApiFactory.create(
             config=GitApiConfig(
@@ -36,7 +45,7 @@ class GitRepoApiFactoryTest(unittest.TestCase):
             repository_name="REPO",
         )
 
-        self.assertEqual(git_repo_api, mock_bitbucket_adapter)
+        self.assertEqual(git_repo_api, mock_logging_proxy)
 
         mock_bitbucket_adapter_constructor.assert_called_with(
             git_provider_url="PROVIDER_URL",
@@ -45,6 +54,7 @@ class GitRepoApiFactoryTest(unittest.TestCase):
             organisation="ORG",
             repository_name="REPO",
         )
+        mock_logging_proxy_constructor.assert_called_with(mock_bitbucket_adapter)
 
     def test_create_bitbucket_missing_url(self):
         try:


### PR DESCRIPTION
- add `GitRepoApiLoggingProxy`
- move API related logging into `GitRepoApiLoggingProxy`
- move 'classic' git related logging into `GitRepo`
