### PR TITLE
feat(create-preview): return preview info as tmp file

### DIFF
--- a/docs/commands/create-preview.md
+++ b/docs/commands/create-preview.md
@@ -58,6 +58,17 @@ previewConfig:
       variable: ROUTE_HOST # this is the resolved host.template from above
 ```
 
+## Returned Information
+
+After running this command you'll find a YAML file at `/tmp/gitopscli-preview-info.yaml`. It contains generated information about your preview environment:
+
+```yaml
+previewId: PREVIEW_ID
+previewIdHash: 685912d3
+routeHost: app.xy-685912d3.example.tld
+namespace: my-app-685912d3-preview
+```
+
 ## Example
 
 ```bash

--- a/gitopscli/commands/create_preview.py
+++ b/gitopscli/commands/create_preview.py
@@ -4,7 +4,7 @@ import shutil
 from dataclasses import dataclass
 from typing import Any, Callable, Dict
 from gitopscli.git_api import GitApiConfig, GitRepo, GitRepoApi, GitRepoApiFactory
-from gitopscli.io_api.yaml_util import update_yaml_file, YAMLException
+from gitopscli.io_api.yaml_util import update_yaml_file, YAMLException, yaml_file_dump
 from gitopscli.gitops_config import GitOpsConfig
 from gitopscli.gitops_exception import GitOpsException
 from .common import load_gitops_config
@@ -41,6 +41,7 @@ class CreatePreviewCommand(Command):
 
     def execute(self,) -> None:
         gitops_config = self.__get_gitops_config()
+        self.__create_preview_info_file(gitops_config)
         route_host = gitops_config.get_route_host(self.__args.preview_id)
 
         team_config_git_repo_api = self.__create_team_config_git_repo_api(gitops_config)
@@ -120,6 +121,18 @@ class CreatePreviewCommand(Command):
             else:
                 logging.info("Keep property '%s' value: %s", replacement.path, replacement_value)
         return any_value_replaced
+
+    def __create_preview_info_file(self, gitops_config: GitOpsConfig):
+        preview_id = self.__args.preview_id
+        yaml_file_dump(
+            {
+                "previewId": preview_id,
+                "previewIdHash": gitops_config.create_hashed_preview_id(preview_id),
+                "routeHost": gitops_config.get_route_host(preview_id),
+                "namespace": gitops_config.get_preview_namespace(preview_id),
+            },
+            "/tmp/gitopscli-preview-info.yaml",
+        )
 
     @staticmethod
     def __update_yaml_file(git_repo: GitRepo, file_path: str, key: str, value: Any) -> bool:

--- a/gitopscli/commands/create_preview.py
+++ b/gitopscli/commands/create_preview.py
@@ -122,7 +122,7 @@ class CreatePreviewCommand(Command):
                 logging.info("Keep property '%s' value: %s", replacement.path, replacement_value)
         return any_value_replaced
 
-    def __create_preview_info_file(self, gitops_config: GitOpsConfig):
+    def __create_preview_info_file(self, gitops_config: GitOpsConfig) -> None:
         preview_id = self.__args.preview_id
         yaml_file_dump(
             {

--- a/gitopscli/gitops_config.py
+++ b/gitopscli/gitops_config.py
@@ -37,15 +37,15 @@ class GitOpsConfig:
             assert isinstance(replacement, self.Replacement), f"replacement[{index}] of wrong type!"
 
     def get_route_host(self, preview_id: str) -> str:
-        hashed_preview_id = self.__create_hashed_preview_id(preview_id)
+        hashed_preview_id = self.create_hashed_preview_id(preview_id)
         return self.route_host_template.replace("{SHA256_8CHAR_BRANCH_HASH}", hashed_preview_id)
 
     def get_preview_namespace(self, preview_id: str) -> str:
-        hashed_preview_id = self.__create_hashed_preview_id(preview_id)
+        hashed_preview_id = self.create_hashed_preview_id(preview_id)
         return f"{self.application_name}-{hashed_preview_id}-preview"
 
     @staticmethod
-    def __create_hashed_preview_id(preview_id: str) -> str:
+    def create_hashed_preview_id(preview_id: str) -> str:
         return hashlib.sha256(preview_id.encode("utf-8")).hexdigest()[:8]
 
     @staticmethod

--- a/tests/commands/test_create_preview.py
+++ b/tests/commands/test_create_preview.py
@@ -3,7 +3,7 @@ import unittest
 import shutil
 import logging
 from unittest.mock import call, Mock
-from gitopscli.io_api.yaml_util import update_yaml_file, YAMLException
+from gitopscli.io_api.yaml_util import update_yaml_file, YAMLException, yaml_file_dump
 from gitopscli.git_api import GitRepo, GitRepoApi, GitRepoApiFactory, GitProvider
 from gitopscli.gitops_config import GitOpsConfig
 from gitopscli.gitops_exception import GitOpsException
@@ -25,6 +25,13 @@ ARGS = CreatePreviewCommand.Args(
     git_hash=DUMMY_GIT_HASH,
 )
 
+INFO_YAML = {
+    "previewId": "PREVIEW_ID",
+    "previewIdHash": "685912d3",
+    "routeHost": "app.xy-685912d3.example.tld",
+    "namespace": "my-app-685912d3-preview",
+}
+
 
 class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
     def setUp(self):
@@ -41,6 +48,9 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         self.update_yaml_file_mock = self.monkey_patch(update_yaml_file)
         self.update_yaml_file_mock.return_value = True
+
+        self.yaml_file_dump_mock = self.monkey_patch(yaml_file_dump)
+        self.yaml_file_dump_mock.return_value = None
 
         self.load_gitops_config_mock = self.monkey_patch(load_gitops_config)
         self.load_gitops_config_mock.return_value = GitOpsConfig(
@@ -90,6 +100,15 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(
+                {
+                    "previewId": "PREVIEW_ID",
+                    "previewIdHash": "685912d3",
+                    "routeHost": "app.xy-685912d3.example.tld",
+                    "namespace": "my-app-685912d3-preview",
+                },
+                "/tmp/gitopscli-preview-info.yaml",
+            ),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -147,6 +166,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -196,6 +216,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -231,6 +252,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -252,6 +274,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -277,6 +300,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -302,6 +326,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),
@@ -332,6 +357,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
+            call.yaml_file_dump(INFO_YAML, "/tmp/gitopscli-preview-info.yaml",),
             call.GitRepoApiFactory.create(ARGS, "TEAM_CONFIG_ORG", "TEAM_CONFIG_REPO",),
             call.GitRepo(self.git_repo_api_mock),
             call.GitRepo.clone(),


### PR DESCRIPTION
Create a tmp file with generated preview infos like the route containing the hashed preview id. This can be used for accessing the preview in following steps of the CI pipeline (e.g. cypress tests).