### PR TITLE
Remove args from doc which went obsolete in #37

### DIFF
--- a/docs/commands/create-pr-preview.md
+++ b/docs/commands/create-pr-preview.md
@@ -69,9 +69,7 @@ gitopscli create-pr-preview \
   --git-email "gitopscli@baloise.dev" \
   --organisation "my-team" \
   --repository-name "app-xy" \
-  --pr-id 4711 \
-  --create-pr \
-  --auto-merge
+  --pr-id 4711
 ```
 
 ## Usage


### PR DESCRIPTION
In #37 the args create-pr & auto-merge for create-pr-preview were removed but the doc isn't updated.