### PR TITLE
feat(cli): allow passing credentials via environment variables

### DIFF
--- a/docs/commands/add-pr-comment.md
+++ b/docs/commands/add-pr-comment.md
@@ -25,8 +25,10 @@ usage: gitopscli add-pr-comment [-h] --username USERNAME --password PASSWORD
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --organisation ORGANISATION
                         Apps Git organisation/projectKey
   --repository-name REPOSITORY_NAME

--- a/docs/commands/create-pr-preview.md
+++ b/docs/commands/create-pr-preview.md
@@ -84,8 +84,10 @@ usage: gitopscli create-pr-preview [-h] --username USERNAME --password PASSWORD
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/docs/commands/create-preview.md
+++ b/docs/commands/create-preview.md
@@ -96,8 +96,10 @@ usage: gitopscli create-preview [-h] --username USERNAME --password PASSWORD
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/docs/commands/delete-pr-preview.md
+++ b/docs/commands/delete-pr-preview.md
@@ -31,8 +31,10 @@ usage: gitopscli delete-pr-preview [-h] --username USERNAME --password
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/docs/commands/delete-preview.md
+++ b/docs/commands/delete-preview.md
@@ -29,8 +29,10 @@ usage: gitopscli delete-preview [-h] --username USERNAME --password PASSWORD
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -136,8 +136,10 @@ optional arguments:
                         desired value as value
   --single-commit [SINGLE_COMMIT]
                         Create only single commit for all updates
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/docs/commands/sync-apps.md
+++ b/docs/commands/sync-apps.md
@@ -75,8 +75,10 @@ usage: gitopscli sync-apps [-h] --username USERNAME --password PASSWORD
 
 optional arguments:
   -h, --help            show this help message and exit
-  --username USERNAME   Git username
-  --password PASSWORD   Git password or token
+  --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
+                        variable)
+  --password PASSWORD   Git password or token (alternative: GITOPSCLI_PASSWORD
+                        env variable)
   --git-user GIT_USER   Git Username
   --git-email GIT_EMAIL
                         Git User Email

--- a/gitopscli/cliparser.py
+++ b/gitopscli/cliparser.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser, ArgumentTypeError
+import os
 import sys
 from typing import List, Tuple, Dict, Any, NoReturn, Callable
 from gitopscli.commands import (
@@ -179,8 +180,18 @@ def __create_version_parser() -> ArgumentParser:
 
 
 def __add_git_credentials_args(deploy_p: ArgumentParser) -> None:
-    deploy_p.add_argument("--username", help="Git username", required=True)
-    deploy_p.add_argument("--password", help="Git password or token", required=True)
+    deploy_p.add_argument(
+        "--username",
+        help="Git username (alternative: GITOPSCLI_USERNAME env variable)",
+        required="GITOPSCLI_USERNAME" not in os.environ,
+        default=os.environ.get("GITOPSCLI_USERNAME"),
+    )
+    deploy_p.add_argument(
+        "--password",
+        help="Git password or token (alternative: GITOPSCLI_PASSWORD env variable)",
+        required="GITOPSCLI_PASSWORD" not in os.environ,
+        default=os.environ.get("GITOPSCLI_PASSWORD"),
+    )
 
 
 def __add_git_commit_user_args(deploy_p: ArgumentParser) -> None:


### PR DESCRIPTION
- `GITOPSCLI_USERNAME` instead of `--username`
- `GITOPSCLI_PASSWORD` instead of `--password`

Resolves #146