### PR TITLE
fix: preserve existing yaml quotes during update

### DIFF
--- a/gitopscli/io_api/yaml_util.py
+++ b/gitopscli/io_api/yaml_util.py
@@ -6,6 +6,9 @@ from ruamel.yaml import YAML, YAMLError
 
 _ARRAY_KEY_SEGMENT_PATTERN = re.compile(r"\[(\d+)\]")
 
+YAML_INSTANCE = YAML()
+YAML_INSTANCE.preserve_quotes = True  # type: ignore
+
 
 class YAMLException(Exception):
     pass
@@ -14,26 +17,26 @@ class YAMLException(Exception):
 def yaml_file_load(file_path: str) -> Any:
     with open(file_path, "r") as stream:
         try:
-            return YAML().load(stream)
+            return YAML_INSTANCE.load(stream)
         except YAMLError as ex:
             raise YAMLException(f"Error parsing YAML file: {file_path}") from ex
 
 
 def yaml_file_dump(yaml: Any, file_path: str) -> None:
     with open(file_path, "w+") as stream:
-        YAML().dump(yaml, stream)
+        YAML_INSTANCE.dump(yaml, stream)
 
 
 def yaml_load(yaml_str: str) -> Any:
     try:
-        return YAML().load(yaml_str)
+        return YAML_INSTANCE.load(yaml_str)
     except YAMLError as ex:
         raise YAMLException(f"Error parsing YAML string '{yaml_str}'") from ex
 
 
 def yaml_dump(yaml: Any) -> str:
     stream = StringIO()
-    YAML().dump(yaml, stream)
+    YAML_INSTANCE.dump(yaml, stream)
     return stream.getvalue().rstrip()
 
 

--- a/tests/io_api/test_yaml_util.py
+++ b/tests/io_api/test_yaml_util.py
@@ -111,6 +111,7 @@ a: # comment 1
   b:
     d: 1 # comment 3
     c: 2 # comment 4
+    e: "expect quotes are preserved"
   e:
   - f: 3 # comment 5
     g: 4 # comment 6
@@ -137,6 +138,7 @@ a: # comment 1
   b:
     d: 1 # comment 3
     c: '2' # comment 4
+    e: "expect quotes are preserved"
   e:
   - f: 3 # comment 5
     g: 42 # comment 6


### PR DESCRIPTION
Preserve existing quotes in YAML files. The philosophy of the gitopscli is to only change the absolute minimum when applying YAML updates.

Fixes #152