### PR TITLE
build: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+fail_fast: true
+repos:
+- repo: local
+  hooks:
+  - id: format-check
+    name: make format-check
+    entry: make format-check
+    language: system
+    pass_filenames: false
+    always_run: true
+  - id: lint
+    name: make lint
+    entry: make lint
+    language: system
+    pass_filenames: false
+    always_run: true
+  - id: mypy
+    name: make mypy
+    entry: make mypy
+    language: system
+    pass_filenames: false
+    always_run: true
+  - id: test
+    name: make test
+    entry: make test
+    language: system
+    pass_filenames: false
+    always_run: true

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BLACK_ARGS = -l 120 -t py37 gitopscli tests setup.py
 init:
 	pip3 install --editable .
 	pip3 install -r requirements-dev.txt
+	pre-commit install
 
 format:
 	black $(BLACK_ARGS)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Currently, we support BitBucket Server, GitHub and Gitlab.
 ```bash
 python3 -m venv venv  # create and activate virtual environment
 source venv/bin/activate  # enter virtual environment
-make init  # install dependencies and setup dev gitopscli
+make init  # install dependencies, setup dev gitopscli, install pre-commit hooks, ...
 deactivate  # leave virtual environment (after development)
 ```
 

--- a/gitopscli/git_api/git_repo.py
+++ b/gitopscli/git_api/git_repo.py
@@ -68,7 +68,7 @@ class GitRepo:
                 logging.info("Creating commit with message: %s", message)
                 repo.config_writer().set_value("user", "name", git_user).release()
                 repo.config_writer().set_value("user", "email", git_email).release()
-                repo.git.commit("-m", message)
+                repo.git.commit("-m", message, "--author", f"{git_user} <{git_email}>")
         except GitError as ex:
             raise GitOpsException(f"Error creating commit.") from ex
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ mkdocs==1.0.4
 mkdocs-material==4.6.3
 mypy==0.790
 typeguard==2.10.0
+pre-commit==2.13.0

--- a/tests/git_api/test_git_repo.py
+++ b/tests/git_api/test_git_repo.py
@@ -33,20 +33,22 @@ class GitRepoTest(unittest.TestCase):
         repo_dir = self.__create_tmp_dir()
 
         repo = Repo.init(repo_dir)
-        repo.config_writer().set_value("user", "name", "unit tester").release()
-        repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+        git_user = "unit tester"
+        git_email = "unit@tester.com"
+        repo.config_writer().set_value("user", "name", git_user).release()
+        repo.config_writer().set_value("user", "email", git_email).release()
 
         with open(f"{repo_dir}/README.md", "w") as readme:
             readme.write("master branch readme")
         repo.git.add("--all")
-        repo.git.commit("-m", "initial commit")
+        repo.git.commit("-m", "initial commit", "--author", f"{git_user} <{git_email}>")
 
         repo.create_head("xyz").checkout()
 
         with open(f"{repo_dir}/README.md", "w") as readme:
             readme.write("xyz branch readme")
         repo.git.add("--all")
-        repo.git.commit("-m", "xyz brach commit")
+        repo.git.commit("-m", "xyz brach commit", "--author", f"{git_user} <{git_email}>")
 
         repo.git.checkout("master")  # master = default branch
         repo.git.config("receive.denyCurrentBranch", "ignore")


### PR DESCRIPTION
Run all checks before every commit for immediate developer feedback.

Necessary fix: Running the tests in the pre-commit hook somehow messes
with the git user/email config used for creating commits during the
tests. Additionally specifying the author of the commits works.