### PR TITLE
New variable syntax

### DIFF
--- a/docs/includes/preview-configuration.md
+++ b/docs/includes/preview-configuration.md
@@ -30,7 +30,7 @@ Make sure that your *app repository* contains a `.gitops.config.yaml` file. This
 apiVersion: v1
 applicationName: app-xy
 previewConfig:
-  host: {PREVIEW_NAMESPACE}.example.tld
+  host: '{PREVIEW_NAMESPACE}.example.tld'
 # template:                              # optional section
 #   organisation: templates              # optional (default: target.organisation)
 #   repository: template-repo            # optional (default: target.repository)
@@ -40,18 +40,18 @@ previewConfig:
     organisation: deployments
     repository: deployment-config-repo
 #   branch: master                       # optional (defaults to repo's default branch)
-    namespace: {APPLICATION_NAME}-{PREVIEW_ID_HASH}-preview  # optional (default: '{APPLICATION_NAME}-{PREVIEW_ID}-{PREVIEW_ID_HASH}-preview',
-                                                             #           Invalid characters in PREVIEW_ID will be replaced. PREVIEW_ID will be
-                                                             #           truncated if max namespace length exceeds 63 chars.)
+    namespace: '{APPLICATION_NAME}-{PREVIEW_ID_HASH}-preview'  # optional (default: '{APPLICATION_NAME}-{PREVIEW_ID}-{PREVIEW_ID_HASH}-preview',
+                                                               #           Invalid characters in PREVIEW_ID will be replaced. PREVIEW_ID will be
+                                                               #           truncated if max namespace length exceeds 63 chars.)
   replace:
     Chart.yaml:
       - path: name
-        value: {PREVIEW_NAMESPACE}
+        value: '{PREVIEW_NAMESPACE}'
     values.yaml:
       - path: app.image
         value: registry.example.tld/my-app:{GIT_HASH}
       - path: route.host
-        value: {PREVIEW_HOST}
+        value: '{PREVIEW_HOST}'
 ```
 
 #### Variables

--- a/tests/commands/test_create_preview.py
+++ b/tests/commands/test_create_preview.py
@@ -54,9 +54,9 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
 
         self.load_gitops_config_mock = self.monkey_patch(load_gitops_config)
         self.load_gitops_config_mock.return_value = GitOpsConfig(
-            api_version=1,
+            api_version=2,
             application_name="my-app",
-            preview_host_template="app.xy-{PREVIEW_ID_HASH}.example.tld",
+            preview_host_template="app.xy-${PREVIEW_ID_HASH}.example.tld",
             preview_template_organisation="PREVIEW_TEMPLATE_ORG",
             preview_template_repository="PREVIEW_TEMPLATE_REPO",
             preview_template_path_template=".preview-templates/my-app",
@@ -64,12 +64,12 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
             preview_target_organisation="PREVIEW_TARGET_ORG",
             preview_target_repository="PREVIEW_TARGET_REPO",
             preview_target_branch=None,
-            preview_target_namespace_template=f"my-app-{{PREVIEW_ID_HASH}}-preview",
+            preview_target_namespace_template="my-app-${PREVIEW_ID_HASH}-preview",
             replacements={
-                "Chart.yaml": [GitOpsConfig.Replacement(path="name", value_template="{PREVIEW_NAMESPACE}"),],
+                "Chart.yaml": [GitOpsConfig.Replacement(path="name", value_template="${PREVIEW_NAMESPACE}"),],
                 "values.yaml": [
-                    GitOpsConfig.Replacement(path="image.tag", value_template="{GIT_HASH}"),
-                    GitOpsConfig.Replacement(path="route.host", value_template="{PREVIEW_HOST}"),
+                    GitOpsConfig.Replacement(path="image.tag", value_template="${GIT_HASH}"),
+                    GitOpsConfig.Replacement(path="route.host", value_template="${PREVIEW_HOST}"),
                 ],
             },
         )

--- a/tests/commands/test_delete_preview.py
+++ b/tests/commands/test_delete_preview.py
@@ -36,7 +36,7 @@ class DeletePreviewCommandTest(MockMixin, unittest.TestCase):
             preview_target_organisation="PREVIEW_TARGET_ORG",
             preview_target_repository="PREVIEW_TARGET_REPO",
             preview_target_branch="target-branch",
-            preview_target_namespace_template=f"APP-{{PREVIEW_ID_HASH}}-preview",
+            preview_target_namespace_template="APP-${PREVIEW_ID_HASH}-preview",
             replacements={},
         )
 

--- a/tests/test_gitops_config_v0.py
+++ b/tests/test_gitops_config_v0.py
@@ -73,7 +73,7 @@ class GitOpsConfigV0Test(unittest.TestCase):
 
     def test_route_host_template(self):
         config = self.load()
-        self.assertEqual(config.preview_host_template, "my-{PREVIEW_ID_HASH}-host-template")
+        self.assertEqual(config.preview_host_template, "my-${PREVIEW_ID_HASH}-host-template")
 
     def test_route_host(self):
         config = self.load()
@@ -97,7 +97,7 @@ class GitOpsConfigV0Test(unittest.TestCase):
 
     def test_namespace_template(self):
         config = self.load()
-        self.assertEqual(config.preview_target_namespace_template, "{APPLICATION_NAME}-{PREVIEW_ID_HASH}-preview")
+        self.assertEqual(config.preview_target_namespace_template, "${APPLICATION_NAME}-${PREVIEW_ID_HASH}-preview")
 
     def test_namespace(self):
         config = self.load()
@@ -109,13 +109,13 @@ class GitOpsConfigV0Test(unittest.TestCase):
 
         self.assertEqual(len(config.replacements["Chart.yaml"]), 1)
         self.assertEqual(config.replacements["Chart.yaml"][0].path, "name")
-        self.assertEqual(config.replacements["Chart.yaml"][0].value_template, "{PREVIEW_NAMESPACE}")
+        self.assertEqual(config.replacements["Chart.yaml"][0].value_template, "${PREVIEW_NAMESPACE}")
 
         self.assertEqual(len(config.replacements["values.yaml"]), 2)
         self.assertEqual(config.replacements["values.yaml"][0].path, "a.b")
-        self.assertEqual(config.replacements["values.yaml"][0].value_template, "{PREVIEW_HOST}")
+        self.assertEqual(config.replacements["values.yaml"][0].value_template, "${PREVIEW_HOST}")
         self.assertEqual(config.replacements["values.yaml"][1].path, "c.d")
-        self.assertEqual(config.replacements["values.yaml"][1].value_template, "{GIT_HASH}")
+        self.assertEqual(config.replacements["values.yaml"][1].value_template, "${GIT_HASH}")
 
     def test_replacements_missing(self):
         del self.yaml["previewConfig"]["replace"]
@@ -147,7 +147,7 @@ class GitOpsConfigV0Test(unittest.TestCase):
 
     def test_replacements_invalid_list_items_unknown_variable(self):
         self.yaml["previewConfig"]["replace"][0]["variable"] = "FOO"
-        self.assert_load_error("Replacement value '{FOO}' for path 'a.b' contains invalid variable: FOO")
+        self.assert_load_error("Replacement value '${FOO}' for path 'a.b' contains invalid variable: FOO")
 
     def test_replacements_invalid_list_items_invalid_variable(self):
         self.yaml["previewConfig"]["replace"][0]["variable"] = "{FOO"

--- a/tests/test_gitops_config_v2.py
+++ b/tests/test_gitops_config_v2.py
@@ -5,31 +5,31 @@ from gitopscli.gitops_config import GitOpsConfig
 from gitopscli.gitops_exception import GitOpsException
 
 
-class GitOpsConfigV1Test(unittest.TestCase):
+class GitOpsConfigV2Test(unittest.TestCase):
     def setUp(self):
         self.yaml = {
-            "apiVersion": "v1",
+            "apiVersion": "v2_beta",
             "applicationName": "my-app",
             "previewConfig": {
-                "host": "my-{PREVIEW_ID}-{PREVIEW_ID_HASH}-host-template",
+                "host": "my-${PREVIEW_ID}-${PREVIEW_ID_HASH}-host-template",
                 "template": {
                     "organisation": "my-template-org",
                     "repository": "my-template-repo",
                     "branch": "my-template-branch",
-                    "path": ".my-template-dir/{APPLICATION_NAME}",
+                    "path": ".my-template-dir/${APPLICATION_NAME}",
                 },
                 "target": {
                     "organisation": "my-target-org",
                     "repository": "my-target-repo",
                     "branch": "my-target-branch",
-                    "namespace": "{APPLICATION_NAME}-{PREVIEW_ID_HASH}-dev",
+                    "namespace": "${APPLICATION_NAME}-${PREVIEW_ID_HASH}-dev",
                 },
                 "replace": {
                     "file_1.yaml": [
-                        {"path": "a.b", "value": "{PREVIEW_HOST}-foo"},
-                        {"path": "c.d", "value": "bar-{PREVIEW_NAMESPACE}"},
+                        {"path": "a.b", "value": "${PREVIEW_HOST}-foo"},
+                        {"path": "c.d", "value": "bar-${PREVIEW_NAMESPACE}"},
                     ],
-                    "file_2.yaml": [{"path": "e.f", "value": "{GIT_HASH}"}],
+                    "file_2.yaml": [{"path": "e.f", "value": "${GIT_HASH}"}],
                 },
             },
         }
@@ -44,7 +44,7 @@ class GitOpsConfigV1Test(unittest.TestCase):
 
     def test_apiVersion(self):
         config = self.load()
-        self.assertEqual(config.api_version, 1)
+        self.assertEqual(config.api_version, 2)
 
     def test_invalid_apiVersion(self):
         self.yaml["apiVersion"] = "foo"
@@ -82,7 +82,7 @@ class GitOpsConfigV1Test(unittest.TestCase):
         self.assert_load_error("Item 'previewConfig.host' should be a string in GitOps config!")
 
     def test_preview_host_contains_invalid_variable(self):
-        self.yaml["previewConfig"]["host"] = "{FOO}-bar"
+        self.yaml["previewConfig"]["host"] = "${FOO}-bar"
         self.assert_load_error("GitOps config template '${FOO}-bar' contains invalid variable: FOO")
 
     def test_preview_template_organisation(self):
@@ -142,7 +142,7 @@ class GitOpsConfigV1Test(unittest.TestCase):
         self.assert_load_error("Item 'previewConfig.template.path' should be a string in GitOps config!")
 
     def test_preview_template_path_contains_invalid_variable(self):
-        self.yaml["previewConfig"]["template"]["path"] = "{FOO}-bar"
+        self.yaml["previewConfig"]["template"]["path"] = "${FOO}-bar"
         self.assert_load_error("GitOps config template '${FOO}-bar' contains invalid variable: FOO")
 
     def test_preview_target_organisation(self):
@@ -221,7 +221,7 @@ class GitOpsConfigV1Test(unittest.TestCase):
         self.assert_load_error("Item 'previewConfig.target.namespace' should be a string in GitOps config!")
 
     def test_preview_target_namespace_invalid_template(self):
-        self.yaml["previewConfig"]["target"]["namespace"] = "-*+§-weird chars-{PREVIEW_ID_HASH}"
+        self.yaml["previewConfig"]["target"]["namespace"] = "-*+§-weird chars-${PREVIEW_ID_HASH}"
         config = self.load()
         with pytest.raises(GitOpsException) as ex:
             config.get_preview_namespace("preview-1")
@@ -240,7 +240,7 @@ class GitOpsConfigV1Test(unittest.TestCase):
         )
 
     def test_preview_target_namespace_contains_invalid_variable(self):
-        self.yaml["previewConfig"]["target"]["namespace"] = "{FOO}-bar"
+        self.yaml["previewConfig"]["target"]["namespace"] = "${FOO}-bar"
         self.assert_load_error("GitOps config template '${FOO}-bar' contains invalid variable: FOO")
 
     def test_replacements(self):
@@ -294,5 +294,5 @@ class GitOpsConfigV1Test(unittest.TestCase):
         )
 
     def test_replacements_invalid_list_items_unknown_variable(self):
-        self.yaml["previewConfig"]["replace"]["file_2.yaml"][0]["value"] = "{FOO}bar"
+        self.yaml["previewConfig"]["replace"]["file_2.yaml"][0]["value"] = "${FOO}bar"
         self.assert_load_error("Replacement value '${FOO}bar' for path 'e.f' contains invalid variable: FOO")


### PR DESCRIPTION
1. doc(GitOpsConfig): Fix config example
    - Fixes #162 (until we officially release and document apiVersion v2)
2. feat(GitOpsConfig): introduce apiVersion v2_beta
    - Version 2 will use different string interpolation (`${VAR}` instead of `{VAR}`). This fixes #162.
    - Version 1 is kept with simple backwards compatability by replacing old variable placeholders with new ones.
    - Version 2 is still beta and not mentioned in the docs yet. This way we can add some more breaking improvements.
