### PR TITLE
Add single quotes around username/password to credentials helper

### DIFF
--- a/gitopscli/git_api/git_repo.py
+++ b/gitopscli/git_api/git_repo.py
@@ -109,7 +109,7 @@ class GitRepo:
         file_path = f"{self.__tmp_dir}/credentials.sh"
         with open(file_path, "w") as text_file:
             text_file.write("#!/bin/sh\n")
-            text_file.write(f"echo username={username}\n")
-            text_file.write(f"echo password={password}\n")
+            text_file.write(f"echo username='{username}'\n")
+            text_file.write(f"echo password='{password}'\n")
         os.chmod(file_path, 0o700)
         return file_path

--- a/tests/git_api/test_git_repo.py
+++ b/tests/git_api/test_git_repo.py
@@ -144,8 +144,8 @@ class GitRepoTest(unittest.TestCase):
             self.assertEqual(
                 """\
 #!/bin/sh
-echo username=User
-echo password=Pass
+echo username='User'
+echo password='Pass'
 """,
                 credentials_file,
             )


### PR DESCRIPTION
To support special characters like \ or # in credentials, single quotes are added 