### PR TITLE
feat: use customizable message templates for PR comments

### DIFF
--- a/docs/includes/preview-configuration.md
+++ b/docs/includes/preview-configuration.md
@@ -25,10 +25,15 @@ Make sure that your *app repository* contains a `.gitops.config.yaml` file. This
 2. templates for host and namespace name
 3. replace values in template files
 4. find repository and branch where the preview should be created (i.e. your *deployment config repository*)
+5. message templates used to comment your pull request
 
 ```yaml
 apiVersion: v2
 applicationName: app-xy
+# messages:                              # optional section
+#   previewEnvCreated: "Created preview at revision ${GIT-HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
+#   previewEnvUpdated: "Updated preview to revision ${GIT-HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
+#   previewEnvAlreadyUpToDate: "Your preview is already up-to-date with revision ${GIT-HASH}."                                       # optional (default: "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}")
 previewConfig:
   host: ${PREVIEW_NAMESPACE}.example.tld
 # template:                              # optional section

--- a/gitopscli/commands/create_pr_preview.py
+++ b/gitopscli/commands/create_pr_preview.py
@@ -46,14 +46,8 @@ class CreatePrPreviewCommand(Command):
             ),
         )
         create_preview_command.register_callbacks(
-            deployment_already_up_to_date_callback=lambda preview_host: add_pr_comment(
-                f"The version `{git_hash}` has already been deployed. Access it here: https://{preview_host}",
-            ),
-            deployment_updated_callback=lambda preview_host: add_pr_comment(
-                f"Preview environment updated to version `{git_hash}`. Access it here: https://{preview_host}"
-            ),
-            deployment_created_callback=lambda preview_host: add_pr_comment(
-                f"New preview environment created for version `{git_hash}`. Access it here: https://{preview_host}"
-            ),
+            deployment_already_up_to_date_callback=add_pr_comment,
+            deployment_updated_callback=add_pr_comment,
+            deployment_created_callback=add_pr_comment,
         )
         create_preview_command.execute()

--- a/gitopscli/gitops_config.py
+++ b/gitopscli/gitops_config.py
@@ -303,12 +303,9 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=0,
             application_name=self.__get_string_value("deploymentConfig.applicationName"),
-            messages_created_template=
-                "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_updated_template=
-                "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_uptodate_template=
-                "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            messages_created_template="New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
             preview_host_template=self.__get_string_value("previewConfig.route.host.template").replace(
                 "{SHA256_8CHAR_BRANCH_HASH}", "${PREVIEW_ID_HASH}"  # backwards compatibility
             ),
@@ -336,12 +333,9 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=1,
             application_name=config.application_name,
-            messages_created_template=
-                "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_updated_template=
-                "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_uptodate_template=
-                "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            messages_created_template="New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
             preview_host_template=add_var_dollar(config.preview_host_template),
             preview_template_organisation=config.preview_template_organisation,
             preview_template_repository=config.preview_template_repository,
@@ -396,15 +390,15 @@ class _GitOpsConfigYamlParser:
             api_version=2,
             application_name=self.__get_string_value("applicationName"),
             messages_created_template=self.__get_string_value_or_default(
-                "messages.created",
+                "messages.previewEnvCreated",
                 "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
             ),
             messages_updated_template=self.__get_string_value_or_default(
-                "messages.updated",
+                "messages.previewEnvUpdated",
                 "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
             ),
             messages_uptodate_template=self.__get_string_value_or_default(
-                "messages.uptodate",
+                "messages.previewEnvAlreadyUpToDate",
                 "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
             ),
             preview_host_template=self.__get_string_value("previewConfig.host"),

--- a/gitopscli/gitops_config.py
+++ b/gitopscli/gitops_config.py
@@ -303,18 +303,12 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=0,
             application_name=self.__get_string_value("deploymentConfig.applicationName"),
-            messages_created_template=self.__get_string_value_or_default(
-                "messages.created",
+            messages_created_template=
                 "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            ),
-            messages_updated_template=self.__get_string_value_or_default(
-                "messages.updated",
+            messages_updated_template=
                 "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            ),
-            messages_uptodate_template=self.__get_string_value_or_default(
-                "messages.uptodate",
+            messages_uptodate_template=
                 "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
-            ),
             preview_host_template=self.__get_string_value("previewConfig.route.host.template").replace(
                 "{SHA256_8CHAR_BRANCH_HASH}", "${PREVIEW_ID_HASH}"  # backwards compatibility
             ),
@@ -342,18 +336,12 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=1,
             application_name=config.application_name,
-            messages_created_template=self.__get_string_value_or_default(
-                "messages.created",
+            messages_created_template=
                 "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            ),
-            messages_updated_template=self.__get_string_value_or_default(
-                "messages.updated",
+            messages_updated_template=
                 "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            ),
-            messages_uptodate_template=self.__get_string_value_or_default(
-                "messages.uptodate",
+            messages_uptodate_template=
                 "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
-            ),
             preview_host_template=add_var_dollar(config.preview_host_template),
             preview_template_organisation=config.preview_template_organisation,
             preview_template_repository=config.preview_template_repository,

--- a/gitopscli/gitops_config.py
+++ b/gitopscli/gitops_config.py
@@ -303,9 +303,12 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=0,
             application_name=self.__get_string_value("deploymentConfig.applicationName"),
-            messages_created_template="New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            messages_created_template="New preview environment created for version `${GIT_HASH}`. "
+            + "Access it here: https://${PREVIEW_HOST}",
+            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. "
+            + "Access it here: https://${PREVIEW_HOST}",
+            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. "
+            + "Access it here: https://${PREVIEW_HOST}",
             preview_host_template=self.__get_string_value("previewConfig.route.host.template").replace(
                 "{SHA256_8CHAR_BRANCH_HASH}", "${PREVIEW_ID_HASH}"  # backwards compatibility
             ),
@@ -333,9 +336,12 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=1,
             application_name=config.application_name,
-            messages_created_template="New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
-            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            messages_created_template="New preview environment created for version `${GIT_HASH}`. "
+            + "Access it here: https://${PREVIEW_HOST}",
+            messages_updated_template="Preview environment updated to version `${GIT_HASH}`. "
+            + "Access it here: https://${PREVIEW_HOST}",
+            messages_uptodate_template="The version `${GIT_HASH}` has already been deployed. "
+            + "Access it here: https://${PREVIEW_HOST}",
             preview_host_template=add_var_dollar(config.preview_host_template),
             preview_template_organisation=config.preview_template_organisation,
             preview_template_repository=config.preview_template_repository,

--- a/gitopscli/gitops_config.py
+++ b/gitopscli/gitops_config.py
@@ -2,6 +2,7 @@ import re
 import hashlib
 from dataclasses import dataclass
 from typing import List, Any, Optional, Dict, Callable, Set
+from string import Template
 
 from gitopscli.gitops_exception import GitOpsException
 
@@ -51,6 +52,10 @@ class GitOpsConfig:  # pylint: disable=too-many-instance-attributes
     application_name: str
 
     preview_host_template: str
+
+    messages_created_template: str
+    messages_updated_template: str
+    messages_uptodate_template: str
 
     preview_template_organisation: str
     preview_template_repository: str
@@ -139,6 +144,26 @@ class GitOpsConfig:  # pylint: disable=too-many-instance-attributes
         if invalid_character:
             raise GitOpsException(f"Invalid character in preview namespace: '{invalid_character[0]}'")
         return preview_namespace
+
+    def get_created_message(self, context: Replacement.PreviewContext) -> str:
+        return self.fill_template(self.messages_created_template, context)
+
+    def get_updated_message(self, context: Replacement.PreviewContext) -> str:
+        return self.fill_template(self.messages_updated_template, context)
+
+    def get_uptodate_message(self, context: Replacement.PreviewContext) -> str:
+        return self.fill_template(self.messages_uptodate_template, context)
+
+    def fill_template(self, template: str, context: Replacement.PreviewContext) -> str:
+        return Template(template).substitute(
+            APPLICATION_NAME=self.application_name,
+            PREVIEW_ID_HASH=self.create_preview_id_hash(context.preview_id),
+            PREVIEW_ID_HASH_SHORT=self.create_preview_id_hash_short(context.preview_id),
+            PREVIEW_ID=self.__sanitize(context.preview_id),
+            PREVIEW_NAMESPACE=self.get_preview_namespace(context.preview_id),
+            PREVIEW_HOST=self.get_preview_host(context.preview_id),
+            GIT_HASH=context.git_hash,
+        )
 
     @staticmethod
     def __assert_variables(template: str, variables: Set[str]) -> None:
@@ -278,6 +303,18 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=0,
             application_name=self.__get_string_value("deploymentConfig.applicationName"),
+            messages_created_template=self.__get_string_value_or_default(
+                "messages.created",
+                "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_updated_template=self.__get_string_value_or_default(
+                "messages.updated",
+                "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_uptodate_template=self.__get_string_value_or_default(
+                "messages.uptodate",
+                "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            ),
             preview_host_template=self.__get_string_value("previewConfig.route.host.template").replace(
                 "{SHA256_8CHAR_BRANCH_HASH}", "${PREVIEW_ID_HASH}"  # backwards compatibility
             ),
@@ -305,6 +342,18 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=1,
             application_name=config.application_name,
+            messages_created_template=self.__get_string_value_or_default(
+                "messages.created",
+                "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_updated_template=self.__get_string_value_or_default(
+                "messages.updated",
+                "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_uptodate_template=self.__get_string_value_or_default(
+                "messages.uptodate",
+                "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            ),
             preview_host_template=add_var_dollar(config.preview_host_template),
             preview_template_organisation=config.preview_template_organisation,
             preview_template_repository=config.preview_template_repository,
@@ -358,6 +407,18 @@ class _GitOpsConfigYamlParser:
         return GitOpsConfig(
             api_version=2,
             application_name=self.__get_string_value("applicationName"),
+            messages_created_template=self.__get_string_value_or_default(
+                "messages.created",
+                "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_updated_template=self.__get_string_value_or_default(
+                "messages.updated",
+                "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}",
+            ),
+            messages_uptodate_template=self.__get_string_value_or_default(
+                "messages.uptodate",
+                "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}",
+            ),
             preview_host_template=self.__get_string_value("previewConfig.host"),
             preview_template_organisation=self.__get_string_value_or_default(
                 "previewConfig.template.organisation", preview_target_organisation

--- a/tests/commands/test_create_pr_preview.py
+++ b/tests/commands/test_create_pr_preview.py
@@ -74,7 +74,9 @@ class CreatePrPreviewCommandTest(MockMixin, unittest.TestCase):
         ]
 
         self.mock_manager.reset_mock()
-        deployment_already_up_to_date_callback("my-route.baloise.com")
+        deployment_already_up_to_date_callback(
+            "The version `5f65cfa04c66444fcb756d6d7f39304d1c18b199` has already been deployed. Access it here: https://my-route.baloise.com"
+        )
         assert self.mock_manager.method_calls == [
             call.GitRepoApi.add_pull_request_comment(
                 4711,
@@ -85,7 +87,9 @@ class CreatePrPreviewCommandTest(MockMixin, unittest.TestCase):
         ]
 
         self.mock_manager.reset_mock()
-        deployment_updated_callback("my-route.baloise.com")
+        deployment_updated_callback(
+            "Preview environment updated to version `5f65cfa04c66444fcb756d6d7f39304d1c18b199`. Access it here: https://my-route.baloise.com"
+        )
         assert self.mock_manager.method_calls == [
             call.GitRepoApi.add_pull_request_comment(
                 4711,
@@ -96,7 +100,9 @@ class CreatePrPreviewCommandTest(MockMixin, unittest.TestCase):
         ]
 
         self.mock_manager.reset_mock()
-        deployment_created_callback("my-route.baloise.com")
+        deployment_created_callback(
+            "New preview environment created for version `5f65cfa04c66444fcb756d6d7f39304d1c18b199`. Access it here: https://my-route.baloise.com"
+        )
         assert self.mock_manager.method_calls == [
             call.GitRepoApi.add_pull_request_comment(
                 4711,

--- a/tests/commands/test_create_preview.py
+++ b/tests/commands/test_create_preview.py
@@ -56,6 +56,9 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         self.load_gitops_config_mock.return_value = GitOpsConfig(
             api_version=2,
             application_name="my-app",
+            messages_created_template="created template ${PREVIEW_ID_HASH}",
+            messages_updated_template="updated template ${PREVIEW_ID_HASH}",
+            messages_uptodate_template="uptodate template ${PREVIEW_ID_HASH}",
             preview_host_template="app.xy-${PREVIEW_ID_HASH}.example.tld",
             preview_template_organisation="PREVIEW_TEMPLATE_ORG",
             preview_template_repository="PREVIEW_TEMPLATE_REPO",
@@ -130,7 +133,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         )
         command.execute()
 
-        deployment_created_callback.assert_called_once_with("app.xy-685912d3.example.tld")
+        deployment_created_callback.assert_called_once_with("created template 685912d3")
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
@@ -200,6 +203,9 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         self.load_gitops_config_mock.return_value = GitOpsConfig(
             api_version=gitops_config.api_version,
             application_name=gitops_config.application_name,
+            messages_created_template=gitops_config.messages_created_template,
+            messages_updated_template=gitops_config.messages_updated_template,
+            messages_uptodate_template=gitops_config.messages_uptodate_template,
             preview_host_template=gitops_config.preview_host_template,
             preview_template_organisation=gitops_config.preview_target_organisation,  # template = target
             preview_template_repository=gitops_config.preview_target_repository,  # template = target
@@ -228,7 +234,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         )
         command.execute()
 
-        deployment_created_callback.assert_called_once_with("app.xy-685912d3.example.tld")
+        deployment_created_callback.assert_called_once_with("created template 685912d3")
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
@@ -307,7 +313,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         )
         command.execute()
 
-        deployment_updated_callback.assert_called_once_with("app.xy-685912d3.example.tld")
+        deployment_updated_callback.assert_called_once_with("updated template 685912d3")
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),
@@ -375,7 +381,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         )
         command.execute()
 
-        deployment_already_up_to_date_callback.assert_called_once_with("app.xy-685912d3.example.tld")
+        deployment_already_up_to_date_callback.assert_called_once_with("uptodate template 685912d3")
 
         assert self.mock_manager.method_calls == [
             call.load_gitops_config(ARGS, "ORGA", "REPO",),

--- a/tests/commands/test_delete_preview.py
+++ b/tests/commands/test_delete_preview.py
@@ -28,6 +28,9 @@ class DeletePreviewCommandTest(MockMixin, unittest.TestCase):
         self.load_gitops_config_mock.return_value = GitOpsConfig(
             api_version=0,
             application_name="APP",
+            messages_created_template="created template ${PREVIEW_ID_HASH}",
+            messages_updated_template="updated template ${PREVIEW_ID_HASH}",
+            messages_uptodate_template="uptodate template ${PREVIEW_ID_HASH}",
             preview_host_template="www.foo.bar",
             preview_template_organisation="PREVIEW_TEMPLATE_ORG",
             preview_template_repository="PREVIEW_TEMPLATE_REPO",


### PR DESCRIPTION
Allows one to define custom message templates in the .gitops.config.yml which are used for the PR comments
If no templates are specified, default messages are used

Example .gitops.config.yml
```apiVersion: v2
applicationName: my-application
messages:
  created: "Created preview for ${GIT_HASH}. You can access your application here: https://prefix-${PREVIEW_HOST}/some-cool-path"
  updated: "Updated preview to ${GIT_HASH}. You can access your application here: https://prefix-${PREVIEW_HOST}/some-cool-path"
  uptodate: "Your application is already up to date with ${GIT_HASH}. You can access your application here: https://prefix-${PREVIEW_HOST}/some-cool-path"
```