### PR TITLE
ci: fix black formatter by pinning click dependency version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==19.10b0
+click==8.0.4  # can be removed after switching to black >=22.3.0 (https://github.com/psf/black/issues/2964)
 coverage==5.3
 pylint==2.4.4
 pytest==5.4.2


### PR DESCRIPTION
Our code formatter `black` uses sub-dependency `click`. The minor release of `click` from 8.0.4 to 8.1.0 breaks `black`. See also https://github.com/psf/black/issues/2964

Quick workaround: Pin `click` to an older version.

Longterm fix: Upgrade `black` to the most recent version. However, this changes the formatting in a few places. That's why I wanted to wait until the other PRs are merged to prevent merge conflicts.