### PR TITLE
fix typo in documentation

### DIFF
--- a/docs/includes/preview-configuration.md
+++ b/docs/includes/preview-configuration.md
@@ -31,8 +31,8 @@ Make sure that your *app repository* contains a `.gitops.config.yaml` file. This
 apiVersion: v2
 applicationName: app-xy
 # messages:                              # optional section
-#   previewEnvCreated: "Created preview at revision ${GIT-HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
-#   previewEnvUpdated: "Updated preview to revision ${GIT-HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
+#   previewEnvCreated: "Created preview at revision ${GIT_HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "New preview environment created for version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
+#   previewEnvUpdated: "Updated preview to revision ${GIT_HASH}. You can access it here: https://${PREVIEW_HOST}/some-fancy-path"    # optional (default: "Preview environment updated to version `${GIT_HASH}`. Access it here: https://${PREVIEW_HOST}")
 #   previewEnvAlreadyUpToDate: "Your preview is already up-to-date with revision ${GIT-HASH}."                                       # optional (default: "The version `${GIT_HASH}` has already been deployed. Access it here: https://${PREVIEW_HOST}")
 previewConfig:
   host: ${PREVIEW_NAMESPACE}.example.tld


### PR DESCRIPTION
Example .gitops.config.yml used invalid template string for git hash