### PR TITLE
feat: support JSONPath

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -15,10 +15,10 @@ backend:
   tag: 1.0.0 # <- and this one
   env:
   - name: TEST
-    value: foo # <- and even one in a list
+    value: foo # <- and this one in a list, selected via sibling value 'TEST'
 ```
 
-With the following command GitOps CLI will update both values to `1.1.0` on the default branch.
+With the following command GitOps CLI will update all values on the default branch.
 
 ```bash
 gitopscli deploy \
@@ -30,8 +30,10 @@ gitopscli deploy \
   --organisation "deployment" \
   --repository-name "myapp-non-prod" \
   --file "example/values.yaml" \
-  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env.[0].value': bar}"
+  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env[?name==''TEST''].value': bar}"
 ```
+
+You could also use the list index to replace the latter (`my-app.env.[0].value`). For more details on the underlying *JSONPath* syntax, please refer to the [documenatation of the used library *jsonpath-ng*](https://github.com/h2non/jsonpath-ng#jsonpath-syntax).
 
 ### Number Of Commits
 
@@ -42,7 +44,7 @@ commit 0dcaa136b4c5249576bb1f40b942bff6ac718144
 Author: GitOpsCLI <gitopscli@baloise.dev>
 Date:   Thu Mar 12 15:30:32 2020 +0100
 
-    changed 'backend.env.[0].value' to 'bar' in example/values.yaml
+    changed 'backend.env[?name=='TEST'].value' to 'bar' in example/values.yaml
 
 commit d98913ad8fecf571d5f8c3635f8070b05c43a9ca
 Author: GitOpsCLI <gitopscli@baloise.dev>
@@ -64,11 +66,11 @@ commit 3b96839e90c35b8decf89f34a65ab6d66c8bab28
 Author: GitOpsCLI <gitopscli@baloise.dev>
 Date:   Thu Mar 12 15:30:00 2020 +0100
 
-    updated 2 values in example/values.yaml
+    updated 3 values in example/values.yaml
 
     frontend.tag: '1.1.0'
     backend.tag: '1.1.0'
-    backend.env.[0].value: 'bar'
+    'backend.env[?name==''TEST''].value': 'bar'
 ```
 
 ### Specific Commit Message
@@ -88,7 +90,7 @@ gitopscli deploy \
   --repository-name "myapp-non-prod" \
   --commit-message "test commit message" \
   --file "example/values.yaml" \
-  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env.[0].value': bar}"
+  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env[?name==''TEST''].value': bar}"
 ```
 
 This will end up in one single commit with your specified commit-message.
@@ -107,7 +109,7 @@ gitopscli deploy \
   --organisation "deployment" \
   --repository-name "myapp-non-prod" \
   --file "example/values.yaml" \
-  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env.[0].value': bar}" \
+  --values "{frontend.tag: 1.1.0, backend.tag: 1.1.0, 'backend.env[?name==''TEST''].value': bar}" \
   --create-pr \
   --auto-merge
 ```

--- a/docs/includes/preview-configuration.md
+++ b/docs/includes/preview-configuration.md
@@ -23,7 +23,7 @@ Make sure that your *app repository* contains a `.gitops.config.yaml` file. This
 
 1. find repository, branch, and folder containing the template
 2. templates for host and namespace name
-3. replace values in template files
+3. replace values in template files (see [`deploy` command](/gitopscli/commands/deploy/) for details on the key syntax)
 4. find repository and branch where the preview should be created (i.e. your *deployment config repository*)
 5. message templates used to comment your pull request
 

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -70,7 +70,7 @@ class DeployCommand(Command):
             except YAMLException as ex:
                 raise GitOpsException(f"Error loading file: {args.file}") from ex
             except KeyError as ex:
-                raise GitOpsException(f"Key '{key}' not found in file: {args.file}") from ex
+                raise GitOpsException(str(ex)) from ex
 
             if not updated_value:
                 logging.info("Yaml property %s already up-to-date", key)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         "GitPython==3.0.6",
         "ruamel.yaml==0.16.5",
+        "jsonpath-ng==1.5.3",
         "atlassian-python-api==1.14.5",
         "PyGithub==1.53",
         "python-gitlab==2.6.0",

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -405,7 +405,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
         )
         with pytest.raises(GitOpsException) as ex:
             DeployCommand(args).execute()
-        self.assertEqual(str(ex.value), "Key 'a.b.c' not found in file: test/file.yml")
+        self.assertEqual(str(ex.value), "'dummy key error'")
 
         assert self.mock_manager.method_calls == [
             call.GitRepoApiFactory.create(args, "ORGA", "REPO"),


### PR DESCRIPTION
Use library `jsonpath-ng` to replace own but limited JSONPath implementation. Especially the filter expressions allow more complex replacements within lists.

Resolves #181.