### PR TITLE
ci: Build docs with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,14 @@
 *
+!docs
 !gitopscli/
 !tests/
 !.pylintrc
+!CONTRIBUTING.md
+!mkdocs.yml
+!Makefile
 !mypy.ini
-!requirements-dev.txt
-!requirements.txt
+!requirements-docs.txt
+!requirements-test.txt
 !setup.py
 
 **/__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: shell
 env:
   global:
     - DOCKER_IMAGE: baloise/gitopscli
+    - DOCKER_BUILDKIT: '1' # use BuildKit backend (https://docs.docker.com/engine/reference/builder/#buildkit)
+    - BUILDKIT_PROGRESS: plain
     # DOCKER_USERNAME
     - secure: "Ecq9r+yXVc9gVdn1e4sDS/yegMKOyN3F6f4jxNSNl1pEkBZayVOvl6seh58sK+QzaIOLlrMYNlOzmWIKaekRuskYLJNYMUh67RJB24knOMSbA0hD3WPO8GbFY1Y/Xe1Gk5zKlLqFKe9OoCbM0ItGIXL2DrFPWl94F1YoZim2h7q6lFEo9NHvYSjreGMcqJujQKoN5/UkO76C3TEKNFXbyxev18nHwXQvqC2axbZONYEQuzYC7dDDAHRMxQ25t2qcWh19f/ssl0qR7VYheBY72Pypvl131+qIxaMl+r/7UeKHnhrM2/ineyo8VPfxhHwar31ldu0YyC0KtSYEMERASsKmJNyaP9d3mo6Vciws/8fGaU0FqlwfRPOhaa/ixMS43qJ4NS9vSogteQJVIIC4B9mHmFvzShDK5aDML+KJ0ehQnayS/30AywS80iSkSWdbkKPAdr+djVhUbey+LAWPVdmJOnIiBET4eSFqJ37dXmcKrhUcfrthL2SftkTGZ4Fm4gHPNYWXIej9N6kTwHlYzRkuJN3PNTLsqp9YE6dUYIUZEu0qkyX2IBljdOxLK5UTKzdkD+j8kLFEP2kN1ELbhP4qEBJj17swycTP9wR4RB+FfjsdeTXonaEOGq8z2CctnczJe87TJ1/GuRj5l/VXiK2ph25El/Axhg5Kv3lHxJw="
     # DOCKER_PASSWORD
@@ -17,12 +19,11 @@ jobs:
     - stage: test
       language: shell
       services: docker
-      script: docker build .
+      script: docker build --target=test .
     - stage: doc
-      language: python
-      python: 3.6
-      install: pip install -r requirements-dev.txt
-      script: mkdocs build
+      language: shell
+      services: docker
+      script: docker build --target=docs-site --output . .
       deploy:
         provider: pages
         strategy: git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ BLACK_ARGS = -l 120 -t py37 gitopscli tests setup.py
 
 init:
 	pip3 install --editable .
-	pip3 install -r requirements-dev.txt
+	pip3 install -r requirements-test.txt
+	pip3 install -r requirements-docs.txt
 	pre-commit install
 
 format:
@@ -28,7 +29,7 @@ coverage:
 checks: format-check lint mypy test
 
 image:
-	docker build -t gitopscli:latest .
+	DOCKER_BUILDKIT=1 docker build --progress=plain -t gitopscli:latest .
 
 docs:
 	mkdocs serve

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs==1.3.0
+mkdocs-material==8.2.12
+markdown-include==0.6.0
+pymdown-extensions==9.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,10 +2,6 @@ black==22.3.0
 coverage==5.3
 pylint==2.4.4
 pytest==5.4.2
-mkdocs==1.3.0
-mkdocs-material==8.2.12
-markdown-include==0.6.0
-pymdown-extensions==9.4
 mypy==0.790
 typeguard==2.10.0
 pre-commit==2.13.0


### PR DESCRIPTION
We're having odd errors in the travis python runner that I cannot reproduce locally.

Solution: Build docs with docker build. With the BuildKit backend it's quite easy to `--output` the site directory.