### PR TITLE
Print hashes of every commit when deploying

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -165,6 +165,8 @@ optional arguments:
   --merge-method MERGE_METHOD
                         Merge Method (e.g., 'squash', 'rebase', 'merge')
                         (default: merge)
+  --json
+                        Print a JSON object containing deployment information
   -v [VERBOSE], --verbose [VERBOSE]
                         Verbose exception logging
 ```

--- a/gitopscli/cliparser.py
+++ b/gitopscli/cliparser.py
@@ -105,6 +105,13 @@ def __create_deploy_parser() -> ArgumentParser:
         type=str,
         default="merge",
     )
+    parser.add_argument(
+        "--json",
+        help="Print a JSON object containing deployment information",
+        nargs="?",
+        type=__parse_bool,
+        default=False,
+    )
     __add_verbose_arg(parser)
     return parser
 

--- a/gitopscli/git_api/git_repo.py
+++ b/gitopscli/git_api/git_repo.py
@@ -67,7 +67,7 @@ class GitRepo:
         except GitError as ex:
             raise GitOpsException(f"Error creating new branch '{branch}'.") from ex
 
-    def commit(self, git_user: str, git_email: str, message: str) -> None:
+    def commit(self, git_user: str, git_email: str, message: str) -> Optional[str]:
         repo = self.__get_repo()
         try:
             repo.git.add("--all")
@@ -76,8 +76,10 @@ class GitRepo:
                 repo.config_writer().set_value("user", "name", git_user).release()
                 repo.config_writer().set_value("user", "email", git_email).release()
                 repo.git.commit("-m", message, "--author", f"{git_user} <{git_email}>")
+                return str(repo.head.commit.hexsha)
         except GitError as ex:
             raise GitOpsException(f"Error creating commit.") from ex
+        return None
 
     def push(self, branch: Optional[str] = None) -> None:
         repo = self.__get_repo()

--- a/tests/test_cliparser.py
+++ b/tests/test_cliparser.py
@@ -284,7 +284,8 @@ usage: gitopscli deploy [-h] --file FILE --values VALUES
                         [--git-provider GIT_PROVIDER]
                         [--git-provider-url GIT_PROVIDER_URL]
                         [--create-pr [CREATE_PR]] [--auto-merge [AUTO_MERGE]]
-                        [--merge-method MERGE_METHOD] [-v [VERBOSE]]
+                        [--merge-method MERGE_METHOD] [--json [JSON]]
+                        [-v [VERBOSE]]
 gitopscli deploy: error: the following arguments are required: --file, --values, --username, --password, --organisation, --repository-name
 """
 
@@ -298,7 +299,8 @@ usage: gitopscli deploy [-h] --file FILE --values VALUES
                         [--git-provider GIT_PROVIDER]
                         [--git-provider-url GIT_PROVIDER_URL]
                         [--create-pr [CREATE_PR]] [--auto-merge [AUTO_MERGE]]
-                        [--merge-method MERGE_METHOD] [-v [VERBOSE]]
+                        [--merge-method MERGE_METHOD] [--json [JSON]]
+                        [-v [VERBOSE]]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -333,6 +335,7 @@ optional arguments:
   --merge-method MERGE_METHOD
                         Merge Method (e.g., 'squash', 'rebase', 'merge')
                         (default: merge)
+  --json [JSON]         Print a JSON object containing deployment information
   -v [VERBOSE], --verbose [VERBOSE]
                         Verbose exception logging
 """


### PR DESCRIPTION
I altered the deploy command so that hashes of all commits are printed and we can use them for postprocessing in our pipeline. I had to update black and reformat a couple of files because of a [compatibility issue](https://github.com/psf/black/issues/2964). Unfortunately I couldn't think of a good way to test the case when there is no output by the deploy command (when no commits are made). Maybe someone of you has an idea how to cleanly mock the nested call to commit. Also I am not too happy with parsing the short hashes from the command line output but this is the return value I get from the commit method.