### PR TITLE
ci: pin Markdown version to 3.3.7

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,3 +2,4 @@ mkdocs==1.3.0
 mkdocs-material==8.2.12
 markdown-include==0.6.0
 pymdown-extensions==9.4
+Markdown==3.3.7


### PR DESCRIPTION
Markdown >= 3.4.1 seems to have introduced some breaking changes (yay, semver :partying_face:) 

https://github.com/mkdocs/mkdocs/issues/2892