### PR TITLE
chore(Upgrade to python 3.10 with compatibility fixes)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,3 @@
+image: gitpod/workspace-python-3.10:2022-10-17-21-33-26
 tasks:
-  - init: pyenv global 3.10.8 && make init && export COLUMNS=80 && gitopscli --help
+  - init: make init && export COLUMNS=80 && gitopscli --help

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,2 @@
 tasks:
-  - init: make init && export COLUMNS=80 && gitopscli --help
+  - init: pyenv global 3.10.8 && make init && export COLUMNS=80 && gitopscli --help

--- a/.pylintrc
+++ b/.pylintrc
@@ -66,7 +66,7 @@ disable=bad-continuation,
         missing-class-docstring,
         too-many-arguments,
         too-many-locals,
-        duplicate-code
+        duplicate-code #check introduced in pylint 2.7.1, seem to usually show false-positives. There is a value in it - but not in automated pipeline usage.
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,8 @@ disable=bad-continuation,
         missing-module-docstring,
         missing-class-docstring,
         too-many-arguments,
-        too-many-locals
+        too-many-locals,
+        duplicate-code
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # =========
-FROM python:3.8-alpine AS base
+FROM python:3.10-alpine AS base
 
 ENV PATH="/opt/venv/bin:$PATH"
 RUN apk add --no-cache git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BLACK_ARGS = -l 120 -t py37 gitopscli tests setup.py
+BLACK_ARGS = -l 120 -t py310 gitopscli tests setup.py
 
 init:
 	pip3 install --editable .
@@ -16,7 +16,7 @@ lint:
 	pylint gitopscli
 
 mypy:
-	python3 -m mypy .
+	python3 -m mypy --install-types --non-interactive .
 
 test:
 	python3 -m pytest -vv -s --typeguard-packages=gitopscli

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.com/baloise/gitopscli.svg?branch=master)](https://travis-ci.com/baloise/gitopscli) 
 [![Latest Release)](https://img.shields.io/github/v/release/baloise/gitopscli)](https://github.com/baloise/gitopscli/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/baloise/gitopscli)](https://hub.docker.com/r/baloise/gitopscli/tags)
-[![Python: 3.8](https://img.shields.io/badge/python-3.8-yellow.svg)](https://www.python.org/downloads/release/python-380/)
+[![Python: 3.10](https://img.shields.io/badge/python-3.10-yellow.svg)](https://www.python.org/downloads/release/python-3108/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Gitpod](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/baloise/gitopscli) 
 [![License](https://img.shields.io/github/license/baloise/gitopscli?color=lightgrey)](https://github.com/baloise/gitopscli/blob/master/LICENSE)

--- a/docs/commands/add-pr-comment.md
+++ b/docs/commands/add-pr-comment.md
@@ -23,7 +23,7 @@ usage: gitopscli add-pr-comment [-h] --username USERNAME --password PASSWORD
                                 PR_ID [--parent-id PARENT_ID] [-v [VERBOSE]]
                                 --text TEXT
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/create-pr-preview.md
+++ b/docs/commands/create-pr-preview.md
@@ -30,7 +30,7 @@ usage: gitopscli create-pr-preview [-h] --username USERNAME --password PASSWORD
                                 --pr-id PR_ID
                                 [--parent-id PARENT_ID] [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/create-preview.md
+++ b/docs/commands/create-preview.md
@@ -42,7 +42,7 @@ usage: gitopscli create-preview [-h] --username USERNAME --password PASSWORD
                                 --preview-id PREVIEW_ID
                                 [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/delete-pr-preview.md
+++ b/docs/commands/delete-pr-preview.md
@@ -29,7 +29,7 @@ usage: gitopscli delete-pr-preview [-h] --username USERNAME --password
                                    [--expect-preview-exists [EXPECT_PREVIEW_EXISTS]]
                                    [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/delete-preview.md
+++ b/docs/commands/delete-preview.md
@@ -27,7 +27,7 @@ usage: gitopscli delete-preview [-h] --username USERNAME --password PASSWORD
                                 [--expect-preview-exists [EXPECT_PREVIEW_EXISTS]]
                                 [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -132,7 +132,7 @@ usage: gitopscli deploy [-h] --file FILE --values VALUES
                         [--create-pr [CREATE_PR]] [--auto-merge [AUTO_MERGE]]
                         [--merge-method MERGE_METHOD] [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --file FILE           YAML file path
   --values VALUES       YAML/JSON object with the YAML path as key and the

--- a/docs/commands/sync-apps.md
+++ b/docs/commands/sync-apps.md
@@ -85,7 +85,7 @@ usage: gitopscli sync-apps [-h] --username USERNAME --password PASSWORD
                            ROOT_ORGANISATION --root-repository-name
                            ROOT_REPOSITORY_NAME
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -12,6 +12,6 @@ gitopscli version
 ```
 usage: gitopscli version [-h]
 
-optional arguments:
+options:
   -h, --help  show this help message and exit
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ usage: gitopscli [-h]
 
 GitOps CLI
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
 
 commands:

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -96,7 +96,7 @@ def __find_apps_config_from_repo(
             apps_from_other_repos.update(__get_applications_from_app_config(app_config_content))
 
     if found_app_config_file is None or found_app_config_file_name is None:
-        raise GitOpsException(f"Couldn't find config file for apps repository in root repository's 'apps/' directory")
+        raise GitOpsException("Couldn't find config file for apps repository in root repository's 'apps/' directory")
 
     return (
         found_app_config_file,

--- a/gitopscli/git_api/git_repo.py
+++ b/gitopscli/git_api/git_repo.py
@@ -78,7 +78,7 @@ class GitRepo:
                 repo.git.commit("-m", message, "--author", f"{git_user} <{git_email}>")
                 return str(repo.head.commit.hexsha)
         except GitError as ex:
-            raise GitOpsException(f"Error creating commit.") from ex
+            raise GitOpsException("Error creating commit.") from ex
         return None
 
     def push(self, branch: Optional[str] = None) -> None:

--- a/gitopscli/git_api/gitlab_git_repo_api_adapter.py
+++ b/gitopscli/git_api/gitlab_git_repo_api_adapter.py
@@ -26,11 +26,11 @@ class GitlabGitRepoApiAdapter(GitRepoApi):
         except requests.exceptions.ConnectionError as ex:
             raise GitOpsException(f"Error connecting to '{git_provider_url}''") from ex
         except gitlab.exceptions.GitlabAuthenticationError as ex:
-            raise GitOpsException("Bad Personal Access Token")
+            raise GitOpsException("Bad Personal Access Token") from ex
         except gitlab.exceptions.GitlabGetError as ex:
             if ex.response_code == 404:
-                raise GitOpsException(f"Repository '{organisation}/{repository_name}' does not exist")
-            raise GitOpsException(f"Error getting repository: '{ex.error_message}'")
+                raise GitOpsException(f"Repository '{organisation}/{repository_name}' does not exist") from ex
+            raise GitOpsException(f"Error getting repository: '{ex.error_message}'") from ex
 
         self.__token_name = username
         self.__access_token = password
@@ -100,5 +100,5 @@ class GitlabGitRepoApiAdapter(GitRepoApi):
         branches = self.__project.branches.list()
         default_branch = next(filter(lambda x: x.default, branches), None)
         if default_branch is None:
-            raise GitOpsException(f"Default branch does not exist")
+            raise GitOpsException("Default branch does not exist")
         return str(default_branch.name)

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,13 @@ warn_unused_configs = True
 
 ignore_missing_imports = True
 follow_imports = silent
+exclude = (?x)(
+    build/lib/*/*
+    | tests/*
+    | venv/Scripts/*
+  )
+
+
 
 [mypy-tests.*]
 ignore_errors = True

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
-black==22.3.0
+black==22.10.0
 coverage==5.3
-pylint==2.4.4
-pytest==5.4.2
-mypy==0.790
+pylint==2.7.1
+pytest==7.1.3
+mypy==0.982
 typeguard==2.10.0
-pre-commit==2.13.0
+pre-commit==2.20.0

--- a/tests/test_cliparser.py
+++ b/tests/test_cliparser.py
@@ -25,7 +25,7 @@ usage: gitopscli [-h]
 
 GitOps CLI
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
 
 commands:
@@ -59,7 +59,7 @@ usage: gitopscli add-pr-comment [-h] --username USERNAME --password PASSWORD
                                 PR_ID [--parent-id PARENT_ID] [-v [VERBOSE]]
                                 --text TEXT
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -114,7 +114,7 @@ usage: gitopscli create-preview [-h] --username USERNAME --password PASSWORD
                                 --git-hash GIT_HASH --preview-id PREVIEW_ID
                                 [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -150,7 +150,7 @@ usage: gitopscli create-pr-preview [-h] --username USERNAME --password
                                    --pr-id PR_ID [--parent-id PARENT_ID]
                                    [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -211,7 +211,7 @@ usage: gitopscli delete-preview [-h] --username USERNAME --password PASSWORD
                                 [--expect-preview-exists [EXPECT_PREVIEW_EXISTS]]
                                 [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -249,7 +249,7 @@ usage: gitopscli delete-pr-preview [-h] --username USERNAME --password
                                    [--expect-preview-exists [EXPECT_PREVIEW_EXISTS]]
                                    [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -302,7 +302,7 @@ usage: gitopscli deploy [-h] --file FILE --values VALUES
                         [--merge-method MERGE_METHOD] [--json [JSON]]
                         [-v [VERBOSE]]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --file FILE           YAML file path
   --values VALUES       YAML/JSON object with the YAML path as key and the
@@ -362,7 +362,7 @@ usage: gitopscli sync-apps [-h] --username USERNAME --password PASSWORD
                            ROOT_ORGANISATION --root-repository-name
                            ROOT_REPOSITORY_NAME
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --username USERNAME   Git username (alternative: GITOPSCLI_USERNAME env
                         variable)
@@ -391,7 +391,7 @@ optional arguments:
 EXPECTED_VERSION_HELP = """\
 usage: gitopscli version [-h]
 
-optional arguments:
+options:
   -h, --help  show this help message and exit
 """
 


### PR DESCRIPTION
Update image python to version 3.10.
changes:
- by default argparse prints options: instead of optional arguments:
- typed-ast prerequisite for mypy 0.790 in version 1.4.3 had problem with new python version, upgraded both to latest
- mypy upgrade required exclusion of some paths
- linter recommendation applied - remove f-strings where unused,
