### PR TITLE
Support new schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ init:
 	pre-commit install
 
 format:
-	black $(BLACK_ARGS)
+	python3 -m black $(BLACK_ARGS)
 
 format-check:
-	black $(BLACK_ARGS) --check
+	python3 -m black $(BLACK_ARGS) --check
 
 lint:
-	pylint gitopscli
+	python3 -m pylint gitopscli
 
 mypy:
 	python3 -m mypy --install-types --non-interactive .

--- a/docs/commands/sync-apps.md
+++ b/docs/commands/sync-apps.md
@@ -35,6 +35,13 @@ bootstrap:
   - name: team-a # <- every entry links to a YAML file in the `apps/` directory
   - name: team-b
 ```
+Alternative, when using a Chart as dependency with an alias 'config':
+```yaml
+config:
+  bootstrap:
+   - name: team-a # <- every entry links to a YAML file in the `apps/` directory
+   - name: team-b
+```
 
 **apps/team-a.yaml**
 ```yaml

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -131,6 +131,8 @@ def __get_bootstrap_entries(root_config_git_repo: GitRepo) -> Any:
         raise GitOpsException("File 'bootstrap/values.yaml' not found in root repository.") from ex
     if "bootstrap" not in bootstrap_yaml:
         raise GitOpsException("Cannot find key 'bootstrap' in 'bootstrap/values.yaml'")
+    if "config" in bootstrap_yaml.key():
+        return bootstrap_yaml["config"]["bootstrap"]
     return bootstrap_yaml["bootstrap"]
 
 

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -130,9 +130,11 @@ def __get_bootstrap_entries(root_config_git_repo: GitRepo) -> Any:
     except FileNotFoundError as ex:
         raise GitOpsException("File 'bootstrap/values.yaml' not found in root repository.") from ex
     if "bootstrap" not in bootstrap_yaml:
+        if "config" in bootstrap_yaml:
+            if "bootstrap" not in bootstrap_yaml["config"]:
+                 raise GitOpsException("Cannot find key 'config.bootstrap' in 'bootstrap/values.yaml'")
+            return bootstrap_yaml["config"]["bootstrap"]
         raise GitOpsException("Cannot find key 'bootstrap' in 'bootstrap/values.yaml'")
-    if "config" in bootstrap_yaml.key():
-        return bootstrap_yaml["config"]["bootstrap"]
     return bootstrap_yaml["bootstrap"]
 
 

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -129,13 +129,11 @@ def __get_bootstrap_entries(root_config_git_repo: GitRepo) -> Any:
         bootstrap_yaml = yaml_file_load(bootstrap_values_file)
     except FileNotFoundError as ex:
         raise GitOpsException("File 'bootstrap/values.yaml' not found in root repository.") from ex
-    if "bootstrap" not in bootstrap_yaml:
-        if "config" in bootstrap_yaml:
-            if "bootstrap" not in bootstrap_yaml["config"]:
-                 raise GitOpsException("Cannot find key 'config.bootstrap' in 'bootstrap/values.yaml'")
-            return bootstrap_yaml["config"]["bootstrap"]
-        raise GitOpsException("Cannot find key 'bootstrap' in 'bootstrap/values.yaml'")
-    return bootstrap_yaml["bootstrap"]
+    if "bootstrap" in bootstrap_yaml:
+        return bootstrap_yaml["bootstrap"]
+    if "config" in bootstrap_yaml and "bootstrap" in bootstrap_yaml["config"]:
+        return bootstrap_yaml["config"]["bootstrap"]
+    raise GitOpsException("Cannot find key 'bootstrap' or 'config.bootstrap' in 'bootstrap/values.yaml'")
 
 
 def __get_repo_apps(team_config_git_repo: GitRepo) -> Set[str]:


### PR DESCRIPTION
Bootstrap file format in root repository was changed. Currently gitopscli will recognize old and new style bootstrap/values.yam; 