### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           node-version: 'lts/*'
       - name: Install dependencies
-        run: npm install semantic-release @semantic-release/exec @google/semantic-release-replace-plugin conventional-changelog-conventionalcommits
+        run: npm install semantic-release @semantic-release/exec semantic-release-replace-plugin conventional-changelog-conventionalcommits
       - name: Release
         if: github.ref == 'refs/heads/master'
         env:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,7 +4,7 @@ tagFormat: "v${version}"
 plugins:
 - "@semantic-release/commit-analyzer"
 - "@semantic-release/release-notes-generator"
-- - "@google/semantic-release-replace-plugin"
+- - "semantic-release-replace-plugin"
   - replacements:
     - files: [ "setup.py "]
       from: "version=\"UNRELEASED\""


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).