### PR TITLE
fix(log-formatting): correct missing coversion type / wrong conversion flag for info log line

### DIFF
--- a/gitopscli/appconfig_api/app_tenant_config.py
+++ b/gitopscli/appconfig_api/app_tenant_config.py
@@ -64,7 +64,7 @@ class AppTenantConfig:
     def __add_new_applications(self, desired_apps: dict[str, Any]) -> None:
         for desired_app_name, desired_app_value in desired_apps.items():
             if desired_app_name not in self.list_apps().keys():
-                logging.info("Adding % in %s applications", desired_app_name, self.file_path)
+                logging.info("Adding %s in %s applications", desired_app_name, self.file_path)
                 self.tenant_config["applications"][desired_app_name] = desired_app_value
                 self.__set_dirty()
 


### PR DESCRIPTION
Seems to be the cause of

```
INFO __sync_apps: Found 6 app(s) in apps repository: ....., cop-3299-test, cop-3299-prod, ....
07:49:02  --- Logging error ---
07:49:02  Traceback (most recent call last):
07:49:02    File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
07:49:02      msg = self.format(record)
07:49:02    File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
07:49:02      return fmt.format(record)
07:49:02    File "/usr/local/lib/python3.10/logging/__init__.py", line 678, in format
07:49:02      record.message = record.getMessage()
07:49:02    File "/usr/local/lib/python3.10/logging/__init__.py", line 368, in getMessage
07:49:02      msg = msg % self.args
07:49:02  TypeError: %i format: a real number is required, not str
07:49:02  Call stack:
07:49:02    File "/opt/venv/bin/gitopscli", line 33, in <module>
07:49:02      sys.exit(load_entry_point('gitopscli==5.7.0', 'console_scripts', 'gitopscli')())
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/__main__.py", line 14, in main
07:49:02      command.execute()
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/commands/sync_apps.py", line 27, in execute
07:49:02      _sync_apps_command(self.__args)
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/commands/sync_apps.py", line 35, in _sync_apps_command
07:49:02      __sync_apps(team_config_git_repo, root_config_git_repo, args.git_user, args.git_email)
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/commands/sync_apps.py", line 53, in __sync_apps
07:49:02      root_repo_tenant.merge_applications(tenant_from_repo)
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/appconfig_api/app_tenant_config.py", line 35, in merge_applications
07:49:02      self.__add_new_applications(desired_apps)
07:49:02    File "/opt/venv/lib/python3.10/site-packages/gitopscli/appconfig_api/app_tenant_config.py", line 67, in __add_new_applications
07:49:02      logging.info("Adding % in %s applications", desired_app_name, self.file_path)
07:49:02  Message: 'Adding % in %s applications'
07:49:02  Arguments: ('cop-3299-prod', '/tmp/gitopscli/ce83d9fe-2031-4dcc-80b9-9c422e4daee5/repo/apps/......yaml')
```

to reproduce:
```
python3
>>> var1="output1"
>>> var2="output2"
>>> print("printing %s in %s" % (var1,var2))
printing output1 in output2
>>> print("printing % in %s" % (var1,var2))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: %i format: a real number is required, not str

```

See also https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting 