### PR TITLE
test: set initial git branch

### DIFF
--- a/tests/git_api/test_git_repo.py
+++ b/tests/git_api/test_git_repo.py
@@ -32,7 +32,7 @@ class GitRepoTest(unittest.TestCase):
     def __create_origin(self):
         repo_dir = self.__create_tmp_dir()
 
-        repo = Repo.init(repo_dir)
+        repo = Repo.init(repo_dir, initial_branch="master")
         git_user = "unit tester"
         git_email = "unit@tester.com"
         repo.config_writer().set_value("user", "name", git_user).release()


### PR DESCRIPTION
Fix git integration test by explicitly setting the initial git branch in case the user installation uses a different default branch name.