### PR TITLE
feat: Pull and rebase before push

### DIFF
--- a/gitopscli/commands/create_preview.py
+++ b/gitopscli/commands/create_preview.py
@@ -101,6 +101,7 @@ class CreatePreviewCommand(Command):
             self.__args.git_author_email,
             message,
         )
+        git_repo.pull_rebase()
         git_repo.push()
 
     def __get_gitops_config(self) -> GitOpsConfig:

--- a/gitopscli/commands/delete_preview.py
+++ b/gitopscli/commands/delete_preview.py
@@ -74,6 +74,7 @@ class DeletePreviewCommand(Command):
             self.__args.git_author_email,
             message,
         )
+        git_repo.pull_rebase()
         git_repo.push()
 
     @staticmethod

--- a/gitopscli/commands/deploy.py
+++ b/gitopscli/commands/deploy.py
@@ -55,6 +55,7 @@ class DeployCommand(Command):
                 logging.info("All values already up-to-date. I'm done here.")
                 return
 
+            git_repo.pull_rebase()
             git_repo.push()
 
         if self.__args.create_pr:

--- a/gitopscli/commands/sync_apps.py
+++ b/gitopscli/commands/sync_apps.py
@@ -103,4 +103,5 @@ def __commit_and_push(
         git_author_email,
         f"{author} updated " + app_file_name,
     )
+    root_config_git_repo.pull_rebase()
     root_config_git_repo.push()

--- a/gitopscli/git_api/git_repo.py
+++ b/gitopscli/git_api/git_repo.py
@@ -105,6 +105,14 @@ class GitRepo:
         if (name and not email) or (not name and email):
             raise GitOpsException("Please provide the name and email address of the Git author or provide neither!")
 
+    def pull_rebase(self) -> None:
+        repo = self.__get_repo()
+        branch = repo.git.branch("--show-current")
+        if not self.__remote_branch_exists(branch):
+            return
+        logging.info("Pull and rebase: %s", branch)
+        repo.git.pull("--rebase")
+
     def push(self, branch: str | None = None) -> None:
         repo = self.__get_repo()
         if not branch:
@@ -121,6 +129,10 @@ class GitRepo:
         repo = self.__get_repo()
         last_commit = repo.head.commit
         return str(repo.git.show("-s", "--format=%an <%ae>", last_commit.hexsha))
+
+    def __remote_branch_exists(self, branch: str) -> bool:
+        repo = self.__get_repo()
+        return bool(repo.git.ls_remote("--heads", "origin", f"refs/heads/{branch}").strip() != "")
 
     def __delete_tmp_dir(self) -> None:
         if self.__tmp_dir:

--- a/tests/commands/test_create_preview.py
+++ b/tests/commands/test_create_preview.py
@@ -107,6 +107,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
         self.template_git_repo_mock.get_full_file_path.side_effect = lambda x: f"/tmp/template-repo/{x}"
         self.template_git_repo_mock.clone.return_value = None
         self.template_git_repo_mock.commit.return_value = None
+        self.template_git_repo_mock.pull_rebase.return_value = None
         self.template_git_repo_mock.push.return_value = None
 
         self.target_git_repo_mock = self.create_mock(GitRepo)
@@ -208,6 +209,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "Create new preview environment for 'my-app' and git hash '3361723dbd91fcfae7b5b8b8b7d462fbc14187a9'.",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 
@@ -312,6 +314,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "Create new preview environment for 'my-app' and git hash '3361723dbd91fcfae7b5b8b8b7d462fbc14187a9'.",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 
@@ -381,6 +384,7 @@ class CreatePreviewCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "Update preview environment for 'my-app' and git hash '3361723dbd91fcfae7b5b8b8b7d462fbc14187a9'.",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 

--- a/tests/commands/test_delete_preview.py
+++ b/tests/commands/test_delete_preview.py
@@ -63,6 +63,7 @@ class DeletePreviewCommandTest(MockMixin, unittest.TestCase):
         self.git_repo_mock.get_full_file_path.side_effect = lambda x: f"/tmp/created-tmp-dir/{x}"
         self.git_repo_mock.clone.return_value = None
         self.git_repo_mock.commit.return_value = None
+        self.git_repo_mock.pull_rebase.return_value = None
         self.git_repo_mock.push.return_value = None
 
         self.seal_mocks()
@@ -100,6 +101,7 @@ class DeletePreviewCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "Delete preview environment for 'APP' and preview id 'PREVIEW_ID'.",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -48,6 +48,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
         self.git_repo_mock.new_branch.return_value = None
         self.example_commit_hash = "5f3a443e7ecb3723c1a71b9744e2993c0b6dfc00"
         self.git_repo_mock.commit.return_value = self.example_commit_hash
+        self.git_repo_mock.pull_rebase.return_value = None
         self.git_repo_mock.push.return_value = None
         self.git_repo_mock.get_full_file_path.side_effect = lambda x: f"/tmp/created-tmp-dir/{x}"
 
@@ -101,6 +102,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "changed 'a.b.d' to 'bar' in test/file.yml",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 
@@ -142,6 +144,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
             call.logging.info("Updated yaml property %s to %s", "a.b.c", "foo"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", None, None, "changed 'a.b.c' to 'foo' in test/file.yml"),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
             call.GitRepoApi.create_pull_request_to_default_branch(
                 "gitopscli-deploy-b973b5bb",
@@ -199,6 +202,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.d", "bar"),
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", None, None, "changed 'a.b.d' to 'bar' in test/file.yml"),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
             call.GitRepoApi.create_pull_request_to_default_branch(
                 "gitopscli-deploy-b973b5bb",
@@ -259,6 +263,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.d", "bar"),
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", None, None, "changed 'a.b.d' to 'bar' in test/file.yml"),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
             call.GitRepoApi.create_pull_request_to_default_branch(
                 "gitopscli-deploy-b973b5bb",
@@ -313,6 +318,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
                 None,
                 "updated 2 values in test/file.yml\n\na.b.c: foo\na.b.d: bar",
             ),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 
@@ -352,6 +358,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.c", "foo"),
             call.logging.info("Updated yaml property %s to %s", "a.b.c", "foo"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", None, None, "changed 'a.b.c' to 'foo' in test/file.yml"),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 
@@ -393,6 +400,7 @@ class DeployCommandTest(MockMixin, unittest.TestCase):
             call.update_yaml_file("/tmp/created-tmp-dir/test/file.yml", "a.b.d", "bar"),
             call.logging.info("Updated yaml property %s to %s", "a.b.d", "bar"),
             call.GitRepo.commit("GIT_USER", "GIT_EMAIL", None, None, "testcommit"),
+            call.GitRepo.pull_rebase(),
             call.GitRepo.push(),
         ]
 

--- a/tests/commands/test_sync_apps.py
+++ b/tests/commands/test_sync_apps.py
@@ -73,6 +73,7 @@ class SyncAppsCommandTest(MockMixin, unittest.TestCase):
         self.root_config_git_repo_mock.get_clone_url.return_value = "https://repository.url/root/root-config.git"
         self.root_config_git_repo_mock.clone.return_value = None
         self.root_config_git_repo_mock.commit.return_value = None
+        self.root_config_git_repo_mock.pull_rebase.return_value = None
         self.root_config_git_repo_mock.push.return_value = None
 
         self.git_repo_api_factory_mock = self.monkey_patch(GitRepoApiFactory)
@@ -166,6 +167,7 @@ class SyncAppsCommandTest(MockMixin, unittest.TestCase):
                 "GIT_AUTHOR_EMAIL",
                 "author updated /tmp/root-config-repo/apps/team-non-prod.yaml",
             ),
+            call.GitRepo_root.pull_rebase(),
             call.GitRepo_root.push(),
             call.GitRepo_root.__exit__(None, None, None),
             call.GitRepo_team.__exit__(None, None, None),

--- a/tests/git_api/test_git_repo.py
+++ b/tests/git_api/test_git_repo.py
@@ -324,13 +324,15 @@ echo password='Pass'
                 outfile.write("local file")
             local_repo = Repo(testee.get_full_file_path("."))
             local_repo.git.add("--all")
-            local_repo.git.commit("-m", "local commit", "--author", "local <local@doe.com>")
+            local_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            local_repo.git.commit("-m", "local commit")
 
             # origin commit
             with Path(f"{origin_repo.working_dir}/origin.md").open("w") as readme:
                 readme.write("origin file")
             origin_repo.git.add("--all")
-            origin_repo.git.commit("-m", "origin commit", "--author", "origin <origin@doe.com>")
+            origin_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            origin_repo.git.commit("-m", "origin commit")
 
             # pull and rebase from remote
             logging_mock.reset_mock()
@@ -360,13 +362,15 @@ echo password='Pass'
                 outfile.write("local file")
             local_repo = Repo(testee.get_full_file_path("."))
             local_repo.git.add("--all")
-            local_repo.git.commit("-m", "local branch commit", "--author", "local <local@doe.com>")
+            local_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            local_repo.git.commit("-m", "local branch commit")
 
             # origin commit
             with Path(f"{origin_repo.working_dir}/origin.md").open("w") as readme:
                 readme.write("origin file")
             origin_repo.git.add("--all")
-            origin_repo.git.commit("-m", "origin branch commit", "--author", "origin <origin@doe.com>")
+            origin_repo.config_writer().set_value("user", "email", "unit@tester.com").release()
+            origin_repo.git.commit("-m", "origin branch commit")
 
             # pull and rebase from remote
             logging_mock.reset_mock()


### PR DESCRIPTION
Resolves #229

If another user pushes changes to the remote repo after gitopscli has cloned it, the subsequent push will fail. Alliviate this problem somewhat by pulling and rebasing local changes on top of any remote changes just before pushing.

For the case of creating a new branch (for a PR), the pull is skipped because it would fail due to the missing remote branch.