### PR TITLE
Fix MkDocs docs rendering and pin Pygments for docs builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ docs = [
     "markdown-include",
     "pymdown-extensions",
     "Markdown",
+    "pygments<2.20",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -554,6 +554,7 @@ docs = [
     { name = "markdown-include" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "pygments" },
     { name = "pymdown-extensions" },
 ]
 test = [
@@ -583,6 +584,7 @@ docs = [
     { name = "markdown-include" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "pygments", specifier = "<2.20" },
     { name = "pymdown-extensions" },
 ]
 test = [
@@ -1119,11 +1121,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Why
Looks like docs have taken a hit: https://baloise.github.io/gitopscli/getting-started/

### What changed
Keep Pygments below 2.20, avoiding the current PyMdown/Pygments incompatibility that was breaking the docs.